### PR TITLE
Add support for checking manifest functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Available subcommands:
 | fullconnectivity | Checks full connectivity in the cluster |
 | kademlia | Checks Kademlia topology in the cluster |
 | localpinning | Checks local pinning ability of the cluster |
+| manifest | Checks manifest functionality on the cluster |
 | peercount | Count peers for all nodes in the cluster |
 | pingpong | Executes ping from all nodes to all other nodes in the cluster |
 | pullsync | Checks pullsync ability of the cluster |
@@ -88,6 +89,15 @@ beekeeper check kademlia --namespace bee --node-count 3
 Example:
 ```bash
 beekeeper check localpinning --namespace bee --node-count 3
+```
+
+### manifest
+
+**manifest** checks manifest functionality on the cluster.
+
+Example:
+```bash
+beekeeper check manifest --namespace bee --node-count 3
 ```
 
 ### peercount

--- a/cmd/beekeeper/cmd/check.go
+++ b/cmd/beekeeper/cmd/check.go
@@ -66,6 +66,7 @@ func (c *command) initCheckCmd() (err error) {
 	cmd.AddCommand(c.initCheckPushSync())
 	cmd.AddCommand(c.initCheckRetrieval())
 	cmd.AddCommand(c.initCheckChunkRepair())
+	cmd.AddCommand(c.initCheckManifest())
 
 	c.root.AddCommand(cmd)
 	return nil

--- a/cmd/beekeeper/cmd/check_manifest.go
+++ b/cmd/beekeeper/cmd/check_manifest.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"github.com/ethersphere/beekeeper/pkg/bee"
+	"github.com/ethersphere/beekeeper/pkg/check/manifest"
+	"github.com/ethersphere/beekeeper/pkg/random"
+	"github.com/spf13/cobra"
+)
+
+func (c *command) initCheckManifest() *cobra.Command {
+	const (
+		optionNameFilesInCollection = "files-in-collection"
+		optionMaxPathnameLength     = "maximum-pathname-length"
+		optionNameSeed              = "seed"
+	)
+
+	cmd := &cobra.Command{
+		Use:   "manifest",
+		Short: "Checks manifest functionality on the cluster",
+		Long: `Checks manifest functionality on the cluster.
+It uploads given number of files archived in a collection to the first node in the cluster, 
+and attempts retrieval of those files from the last node in the cluster.`,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			cluster, err := bee.NewCluster(bee.ClusterOptions{
+				APIScheme:               c.config.GetString(optionNameAPIScheme),
+				APIHostnamePattern:      c.config.GetString(optionNameAPIHostnamePattern),
+				APIDomain:               c.config.GetString(optionNameAPIDomain),
+				APIInsecureTLS:          insecureTLSAPI,
+				DebugAPIScheme:          c.config.GetString(optionNameDebugAPIScheme),
+				DebugAPIHostnamePattern: c.config.GetString(optionNameDebugAPIHostnamePattern),
+				DebugAPIDomain:          c.config.GetString(optionNameDebugAPIDomain),
+				DebugAPIInsecureTLS:     insecureTLSDebugAPI,
+				DisableNamespace:        disableNamespace,
+				Namespace:               c.config.GetString(optionNameNamespace),
+				Size:                    c.config.GetInt(optionNameNodeCount),
+			})
+			if err != nil {
+				return err
+			}
+
+			var seed int64
+			if cmd.Flags().Changed("seed") {
+				seed = c.config.GetInt64(optionNameSeed)
+			} else {
+				seed = random.Int64()
+			}
+
+			return manifest.Check(cluster, manifest.Options{
+				FilesInCollection: c.config.GetInt(optionNameFilesInCollection),
+				MaxPathnameLength: c.config.GetInt32(optionMaxPathnameLength),
+				Seed:              seed,
+			})
+
+		},
+		PreRunE: c.checkPreRunE,
+	}
+
+	cmd.Flags().Int(optionNameFilesInCollection, 10, "number of files to upload in single collection")
+	cmd.Flags().Int32(optionMaxPathnameLength, 64, "maximum pathname length for files")
+	cmd.Flags().Int64P(optionNameSeed, "s", 0, "seed for generating files; if not set, will be random")
+
+	return cmd
+}

--- a/pkg/beeclient/api/api.go
+++ b/pkg/beeclient/api/api.go
@@ -29,6 +29,7 @@ type Client struct {
 	Bytes  *BytesService
 	Chunks *ChunksService
 	Files  *FilesService
+	Dirs   *DirsService
 }
 
 // ClientOptions holds optional parameters for the Client.
@@ -56,6 +57,7 @@ func newClient(httpClient *http.Client) (c *Client) {
 	c.Bytes = (*BytesService)(&c.service)
 	c.Chunks = (*ChunksService)(&c.service)
 	c.Files = (*FilesService)(&c.service)
+	c.Dirs = (*DirsService)(&c.service)
 	return c
 }
 

--- a/pkg/beeclient/api/dirs.go
+++ b/pkg/beeclient/api/dirs.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// DirsService represents Bee's Dirs service
+type DirsService service
+
+// Download downloads data from the node
+func (s *DirsService) Download(ctx context.Context, a swarm.Address, path string) (resp io.ReadCloser, err error) {
+	return s.client.requestData(ctx, http.MethodGet, "/"+apiVersion+"/bzz/"+a.String()+"/"+path, nil, nil)
+}
+
+// DirsUploadResponse represents Upload's response
+type DirsUploadResponse struct {
+	Reference swarm.Address `json:"reference"`
+}
+
+// Upload uploads TAR collection to the node
+func (s *DirsService) Upload(ctx context.Context, data io.Reader, size int64) (resp DirsUploadResponse, err error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/x-tar")
+	header.Set("Content-Length", strconv.FormatInt(size, 10))
+
+	err = s.client.requestWithHeader(ctx, http.MethodPost, "/"+apiVersion+"/dirs", header, data, &resp)
+
+	return
+}

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -1,0 +1,134 @@
+package manifest
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+
+	"github.com/ethersphere/beekeeper/pkg/bee"
+	"github.com/ethersphere/beekeeper/pkg/random"
+)
+
+// Options represents manifest options
+type Options struct {
+	FilesInCollection int
+	MaxPathnameLength int32
+	Seed              int64
+}
+
+var errManifest = errors.New("manifest")
+
+func Check(c bee.Cluster, o Options) error {
+	ctx := context.Background()
+	rnd := random.PseudoGenerator(o.Seed)
+
+	fmt.Printf("Seed: %d\n", o.Seed)
+
+	overlays, err := c.Overlays(ctx)
+	if err != nil {
+		return err
+	}
+
+	files, err := generateFiles(rnd, o.FilesInCollection, o.MaxPathnameLength)
+	if err != nil {
+		return err
+	}
+
+	tarReader, err := tarFiles(files)
+	if err != nil {
+		return err
+	}
+
+	tarFile := bee.NewBufferFile("", tarReader)
+
+	if err := c.Nodes[0].UploadCollection(ctx, &tarFile); err != nil {
+		return fmt.Errorf("node %d: %w", 0, err)
+	}
+
+	lastNodeIndex := c.Size() - 1
+
+	for i, file := range files {
+
+		size, hash, err := c.Nodes[lastNodeIndex].DownloadManifestFile(ctx, tarFile.Address(), file.Name())
+		if err != nil {
+			return fmt.Errorf("node %d: %w", lastNodeIndex, err)
+		}
+
+		if !bytes.Equal(file.Hash(), hash) {
+			fmt.Printf("Node %d. File %d not retrieved successfully. Uploaded size: %d Downloaded size: %d Node: %s File: %s/%s\n", lastNodeIndex, i, file.Size(), size, overlays[lastNodeIndex].String(), tarFile.Address().String(), file.Name())
+			return errManifest
+		}
+
+		fmt.Printf("Node %d. File %d retrieved successfully. Node: %s File: %s/%s\n", lastNodeIndex, i, overlays[lastNodeIndex].String(), tarFile.Address().String(), file.Name())
+	}
+
+	return nil
+}
+
+func generateFiles(r *rand.Rand, filesCount int, maxPathnameLength int32) ([]bee.File, error) {
+	files := make([]bee.File, filesCount)
+
+	for i := 0; i < filesCount; i++ {
+		pathnameLength := int64(r.Int31n(maxPathnameLength))
+
+		b := make([]byte, pathnameLength)
+
+		_, err := r.Read(b)
+		if err != nil {
+			return nil, err
+		}
+
+		pathname := hex.EncodeToString(b)
+
+		file := bee.NewRandomFile(r, pathname, pathnameLength)
+
+		err = file.CalculateHash()
+		if err != nil {
+			return nil, err
+		}
+
+		files[i] = file
+	}
+
+	return files, nil
+}
+
+// tarFiles receives an array of files and creates a new tar archive with those
+// files as a collection.
+func tarFiles(files []bee.File) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	for _, file := range files {
+		// create tar header and write it
+		hdr := &tar.Header{
+			Name: file.Name(),
+			Mode: 0600,
+			Size: file.Size(),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+
+		b, err := ioutil.ReadAll(file.DataReader())
+		if err != nil {
+			return nil, err
+		}
+
+		// write the file data to the tar
+		if _, err := tw.Write(b); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}


### PR DESCRIPTION
It generates number of files and creates TAR archive from them.
This archive is uploaded and each file is checked if it is valid through `bzz` endpoint, thus testing manifests in `bee` project.