### PR TITLE
instant chunk repair

### DIFF
--- a/pkg/check/chunkrepair/chunkrepair.go
+++ b/pkg/check/chunkrepair/chunkrepair.go
@@ -46,7 +46,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 
 	pusher.Format(expfmt.FmtText)
 
-	if err := fullconnectivity.Check(c); err != nil {
+	if err := fullconnectivity.Check(c); err == nil {
 		return errFullConnectivity
 	}
 

--- a/pkg/check/chunkrepair/chunkrepair.go
+++ b/pkg/check/chunkrepair/chunkrepair.go
@@ -9,13 +9,13 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/prometheus/common/expfmt"
+
 	"github.com/ethersphere/beekeeper/pkg/bee"
 	"github.com/ethersphere/beekeeper/pkg/check/fullconnectivity"
 	"github.com/ethersphere/beekeeper/pkg/random"
-	"github.com/prometheus/client_golang/prometheus/push"
-	"github.com/prometheus/common/expfmt"
 )
 
 // Options represents chunk repair check options
@@ -111,10 +111,6 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 			if bytes.Equal(data, chunk.Data()) {
 				return fmt.Errorf("should not have received chunk")
 			}
-		}
-
-		if !errors.Is(err, storage.ErrNotFound) {
-			return err
 		}
 
 		// 5) Now trigger downloading of the chunk from nodeC again (this time it should trigger chunk repair )


### PR DESCRIPTION
Pick 3 nodes `NodeA`, `NodeB`, `NodeC` and a chunk `ch`, such that

`NodeA` is farthest from `NodeC` in the cluster
chunk address of `ch` is the closest to `NodeB`

- Upload and pin the chunk in `NodeA`
- Check if it reached `NodeB`
- Download the chunk from NodeC
- Delete chunk from all nodes except `NodeA`
- Now try downloading with `NodeA` as target (this time we should get the repaired chunk)
- Download the chunk again without target (it should succeed now as chunk repairing would have placed the chunk in proper node in the network)