### PR TITLE
baseline local pinning tests

### DIFF
--- a/pkg/bee/node.go
+++ b/pkg/bee/node.go
@@ -363,9 +363,9 @@ func (n *Node) RemoveChunk(ctx context.Context, c *Chunk) (err error) {
 }
 
 // UploadFile uploads file to the node
-func (n *Node) UploadFile(ctx context.Context, f *File) (err error) {
+func (n *Node) UploadFile(ctx context.Context, f *File, pin bool) (err error) {
 	h := fileHahser()
-	r, err := n.api.Files.Upload(ctx, f.Name(), io.TeeReader(f.DataReader(), h), f.Size())
+	r, err := n.api.Files.Upload(ctx, f.Name(), io.TeeReader(f.DataReader(), h), f.Size(), pin)
 	if err != nil {
 		return fmt.Errorf("upload file: %w", err)
 	}

--- a/pkg/beeclient/api/files.go
+++ b/pkg/beeclient/api/files.go
@@ -24,10 +24,13 @@ type FilesUploadResponse struct {
 }
 
 // Upload uploads files to the node
-func (f *FilesService) Upload(ctx context.Context, name string, data io.Reader, size int64) (resp FilesUploadResponse, err error) {
+func (f *FilesService) Upload(ctx context.Context, name string, data io.Reader, size int64, pin bool) (resp FilesUploadResponse, err error) {
 	header := make(http.Header)
 	header.Set("Content-Type", "application/octet-stream")
 	header.Set("Content-Length", strconv.FormatInt(size, 10))
+	if pin {
+		header.Set("Swarm-Pin", "true")
+	}
 
 	err = f.client.requestWithHeader(ctx, http.MethodPost, "/"+apiVersion+"/files?"+url.QueryEscape("name="+name), header, data, &resp)
 	return

--- a/pkg/check/balances/balances.go
+++ b/pkg/check/balances/balances.go
@@ -44,7 +44,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 		// upload file to random node
 		uIndex := rnd.Intn(c.Size())
 		file := bee.NewRandomFile(rnd, fmt.Sprintf("%s-%d", o.FileName, uIndex), o.FileSize)
-		if err := c.Nodes[uIndex].UploadFile(ctx, &file); err != nil {
+		if err := c.Nodes[uIndex].UploadFile(ctx, &file, false); err != nil {
 			return fmt.Errorf("node %d: %w", uIndex, err)
 		}
 		fmt.Printf("File %s uploaded successfully to node %s\n", file.Address().String(), overlays[uIndex].String())

--- a/pkg/check/fileretrieval/fileretrieval.go
+++ b/pkg/check/fileretrieval/fileretrieval.go
@@ -51,7 +51,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 			file := bee.NewRandomFile(rnds[i], fmt.Sprintf("%s-%d-%d", o.FileName, i, j), o.FileSize)
 
 			t0 := time.Now()
-			if err := c.Nodes[i].UploadFile(ctx, &file); err != nil {
+			if err := c.Nodes[i].UploadFile(ctx, &file, false); err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
 			d0 := time.Since(t0)
@@ -119,7 +119,7 @@ func CheckFull(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) 
 			file := bee.NewRandomFile(rnds[i], fmt.Sprintf("%s-%d-%d", o.FileName, i, j), o.FileSize)
 
 			t0 := time.Now()
-			if err := c.Nodes[i].UploadFile(ctx, &file); err != nil {
+			if err := c.Nodes[i].UploadFile(ctx, &file, false); err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
 			d0 := time.Since(t0)

--- a/pkg/check/fileretrievaldynamic/fileretrievaldynamic.go
+++ b/pkg/check/fileretrievaldynamic/fileretrievaldynamic.go
@@ -68,7 +68,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 	uIndex := rnd.Intn(c.Size())
 	file := bee.NewRandomFile(rnd, fmt.Sprintf("%s-%d", o.FileName, uIndex), o.FileSize)
 	t0 := time.Now()
-	if err := c.Nodes[uIndex].UploadFile(ctx, &file); err != nil {
+	if err := c.Nodes[uIndex].UploadFile(ctx, &file, false); err != nil {
 		return fmt.Errorf("node %d: %w", uIndex, err)
 	}
 	d0 := time.Since(t0)


### PR DESCRIPTION
This PR enables usage of the `Swarm-Pin` header for uploads in order to upload and pin on local pinning tests.
It removes all sorts of checks that were done since they simply do not factor the fact that we need to pin multiple chunks, and we need to list all pinned chunks which is not possible right now, since paging is not implemented and listing pinned chunks simply cannot account for all of the pinned chunks. Thus, an exhaustive check cannot be made at this point. Once paging is done on listing pinned chunks we can implement verification of pinned chunks and also do unpinning tests.

Closes https://github.com/ethersphere/bee/issues/248.