### PR TITLE
Add pushsync check for files using tags

### DIFF
--- a/pkg/bee/node.go
+++ b/pkg/bee/node.go
@@ -411,7 +411,21 @@ func (n *Node) RemoveChunk(ctx context.Context, c *Chunk) (err error) {
 // UploadFile uploads file to the node
 func (n *Node) UploadFile(ctx context.Context, f *File, pin bool) (err error) {
 	h := fileHahser()
-	r, err := n.api.Files.Upload(ctx, f.Name(), io.TeeReader(f.DataReader(), h), f.Size(), pin)
+	r, err := n.api.Files.Upload(ctx, f.Name(), io.TeeReader(f.DataReader(), h), f.Size(), pin, 0)
+	if err != nil {
+		return fmt.Errorf("upload file: %w", err)
+	}
+
+	f.address = r.Reference
+	f.hash = h.Sum(nil)
+
+	return
+}
+
+// UploadFileWithTag uploads file with tag to the node
+func (n *Node) UploadFileWithTag(ctx context.Context, f *File, pin bool, tagUID uint32) (err error) {
+	h := fileHahser()
+	r, err := n.api.Files.Upload(ctx, f.Name(), io.TeeReader(f.DataReader(), h), f.Size(), pin, tagUID)
 	if err != nil {
 		return fmt.Errorf("upload file: %w", err)
 	}
@@ -450,4 +464,26 @@ func (n *Node) DownloadManifestFile(ctx context.Context, a swarm.Address, path s
 	}
 
 	return size, h.Sum(nil), nil
+}
+
+// CreateTag creates tag on the node
+func (n *Node) CreateTag(ctx context.Context) (resp api.TagResponse, err error) {
+
+	resp, err = n.api.Tags.CreateTag(ctx)
+	if err != nil {
+		return resp, fmt.Errorf("create tag: %w", err)
+	}
+
+	return
+}
+
+// GetTag retrieves tag from node
+func (n *Node) GetTag(ctx context.Context, tagUID uint32) (resp api.TagResponse, err error) {
+
+	resp, err = n.api.Tags.GetTag(ctx, tagUID)
+	if err != nil {
+		return resp, fmt.Errorf("get tag: %w", err)
+	}
+
+	return
 }

--- a/pkg/beeclient/api/api.go
+++ b/pkg/beeclient/api/api.go
@@ -32,6 +32,7 @@ type Client struct {
 	Files   *FilesService
 	Dirs    *DirsService
 	Pinning *PinningService
+	Tags    *TagsService
 }
 
 // ClientOptions holds optional parameters for the Client.
@@ -61,6 +62,7 @@ func newClient(httpClient *http.Client) (c *Client) {
 	c.Files = (*FilesService)(&c.service)
 	c.Dirs = (*DirsService)(&c.service)
 	c.Pinning = (*PinningService)(&c.service)
+	c.Tags = (*TagsService)(&c.service)
 	return c
 }
 

--- a/pkg/beeclient/api/files.go
+++ b/pkg/beeclient/api/files.go
@@ -24,12 +24,15 @@ type FilesUploadResponse struct {
 }
 
 // Upload uploads files to the node
-func (f *FilesService) Upload(ctx context.Context, name string, data io.Reader, size int64, pin bool) (resp FilesUploadResponse, err error) {
+func (f *FilesService) Upload(ctx context.Context, name string, data io.Reader, size int64, pin bool, tagUID uint32) (resp FilesUploadResponse, err error) {
 	header := make(http.Header)
 	header.Set("Content-Type", "application/octet-stream")
 	header.Set("Content-Length", strconv.FormatInt(size, 10))
 	if pin {
 		header.Set("Swarm-Pin", "true")
+	}
+	if tagUID != 0 {
+		header.Set("Swarm-Tag-Uid", strconv.FormatUint(uint64(tagUID), 10))
 	}
 
 	err = f.client.requestWithHeader(ctx, http.MethodPost, "/"+apiVersion+"/files?"+url.QueryEscape("name="+name), header, data, &resp)

--- a/pkg/beeclient/api/tags.go
+++ b/pkg/beeclient/api/tags.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// TagsService represents Bee's Tag service
+type TagsService service
+
+type TagResponse struct {
+	Total     int64         `json:"total"`
+	Split     int64         `json:"split"`
+	Seen      int64         `json:"seen"`
+	Stored    int64         `json:"stored"`
+	Sent      int64         `json:"sent"`
+	Synced    int64         `json:"synced"`
+	Uid       uint32        `json:"uid"`
+	Name      string        `json:"name"`
+	Address   swarm.Address `json:"address"`
+	StartedAt time.Time     `json:"startedAt"`
+}
+
+// CreateTag creates new tag
+func (p *TagsService) CreateTag(ctx context.Context) (resp TagResponse, err error) {
+
+	err = p.client.requestJSON(ctx, http.MethodPost, "/tags", nil, &resp)
+	return
+}
+
+// GetTag creates new tag
+func (p *TagsService) GetTag(ctx context.Context, tagUID uint32) (resp TagResponse, err error) {
+
+	tag := strconv.FormatUint(uint64(tagUID), 10)
+
+	err = p.client.requestJSON(ctx, http.MethodGet, "/tags/"+tag, nil, &resp)
+	return
+}


### PR DESCRIPTION
Introduces additional check for 'pushsync' that uploads files to the node (with tag configured), and then checks if counters from tag are expected.
This change also adds `TagsService`, and accompanying functions, to allow using that API.

From the tag counters, `split` value is used as expected number of chunks that need to be pushed, `sent` value is used to see how many chunks have been pushed so far, and `seen` value as number of chunks that are left on the uploading node, and not synced (due to the distribution of chunks through the cluster). For this `seen` value, I was not aware, but have observed on last testing session (generally was always `0`).

In the 'normal' operation, these numbers should usually match, otherwise it might indicate there is some problem.

These changes have been tested on some previous Bee version (before one revert regarding this), and has shown 10-15% more synced chunks.

relates to: [ethersphere/bee#885](https://github.com/ethersphere/bee/issues/885)