### PR TITLE
Fix flaky tests

### DIFF
--- a/pkg/bee/chunk.go
+++ b/pkg/bee/chunk.go
@@ -33,15 +33,6 @@ func NewChunk(data []byte) (Chunk, error) {
 	return Chunk{data: data}, nil
 }
 
-// NewChunk returns new chunk
-func NewChunkA(data []byte, a swarm.Address) (Chunk, error) {
-	if len(data) > MaxChunkSize {
-		return Chunk{}, fmt.Errorf("create chunk: requested size too big (max %d bytes)", MaxChunkSize)
-	}
-
-	return Chunk{data: data, address: a}, nil
-}
-
 // NewRandomChunk returns new pseudorandom chunk
 func NewRandomChunk(r *rand.Rand) (Chunk, error) {
 	data := make([]byte, r.Intn(MaxChunkSize))

--- a/pkg/check/pullsync/pullsync.go
+++ b/pkg/check/pullsync/pullsync.go
@@ -46,22 +46,49 @@ func Check(c bee.Cluster, o Options) (err error) {
 	for i := 0; i < o.UploadNodeCount; i++ {
 		for j := 0; j < o.ChunksPerNode; j++ {
 			var (
-				chunk            bee.Chunk
-				err              error
-				replicatingNodes []swarm.Address
-				nnRep            int
+				chunk               bee.Chunk
+				err                 error
+				replicatingNodes    []swarm.Address
+				nnRep, peerPoBinRep int
 			)
 
 			chunk, err = bee.NewRandomChunk(rnds[i])
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
-			addr, err := chunk.Address(), c.Nodes[i].UploadChunk(ctx, &chunk, api.UploadOptions{Pin: false})
+			addr, err := c.Nodes[i].UploadBytes(ctx, chunk.Data(), api.UploadOptions{Pin: false})
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
-
+			uploaderToChunkPo := swarm.Proximity(overlays[i].Bytes(), addr.Bytes())
 			fmt.Printf("Uploaded chunk %s\n", addr.String())
+
+			// check uploader and non-NN replication
+			uploaderTopology := topologies[i]
+			for _, bin := range uploaderTopology.Bins {
+				for _, peer := range bin.ConnectedPeers {
+					peer := peer
+					pivotToUploaderPo := swarm.Proximity(peer.Bytes(), overlays[i].Bytes())
+					pidx := findIndex(overlays, peer)
+					pivotTopology := topologies[pidx]
+					pivotDepth := pivotTopology.Depth
+					switch pivotPo := int(swarm.Proximity(addr.Bytes(), peer.Bytes())); {
+					case pivotPo >= pivotDepth:
+						// chunk within replicating node depth
+						if findIndex(replicatingNodes, peer) == -1 {
+							replicatingNodes = append(replicatingNodes, peer)
+							nnRep++
+						}
+					case pivotPo != 0 && uploaderToChunkPo != 0 && pivotPo < pivotDepth && uploaderToChunkPo == pivotToUploaderPo:
+						// if the po of the chunk with the uploader == to our po with the uploader, then we need to sync it
+						// chunk outside our depth
+						if findIndex(replicatingNodes, peer) == -1 {
+							replicatingNodes = append(replicatingNodes, peer)
+							peerPoBinRep++
+						}
+					}
+				}
+			}
 
 			// check closest and NN replication (non-nn replication is not realistic)
 			closest, err := chunk.ClosestNode(overlays)
@@ -70,21 +97,33 @@ func Check(c bee.Cluster, o Options) (err error) {
 			}
 			index := findIndex(overlays, closest)
 			fmt.Printf("Upload node %d. Chunk: %d. Closest: %d %s\n", i, j, index, closest.String())
+
 			topology, err := c.Nodes[index].Topology(ctx)
 			if err != nil {
 				return fmt.Errorf("node %d: %w", index, err)
 			}
+			po := swarm.Proximity(addr.Bytes(), closest.Bytes())
 			for _, v := range topology.Bins {
 				for _, peer := range v.ConnectedPeers {
 					peer := peer
+					pivotToClosestPo := swarm.Proximity(peer.Bytes(), closest.Bytes())
 					pidx := findIndex(overlays, peer)
 					pivotTopology := topologies[pidx]
 					pivotDepth := pivotTopology.Depth
-					if pivotPo := int(swarm.Proximity(addr.Bytes(), peer.Bytes())); pivotPo >= pivotDepth {
+					switch pivotPo := int(swarm.Proximity(addr.Bytes(), peer.Bytes())); {
+					case pivotPo >= pivotDepth:
 						// chunk within replicating node depth
 						if findIndex(replicatingNodes, peer) == -1 {
 							replicatingNodes = append(replicatingNodes, peer)
 							nnRep++
+						}
+					case pivotPo != 0 && pivotPo < pivotDepth && po == pivotToClosestPo:
+						// if the po of the chunk with the closest == to our po with the closest, then we need to sync it
+						// chunk outside our depth
+						// po with chunk must equal po with closest
+						if findIndex(replicatingNodes, peer) == -1 {
+							replicatingNodes = append(replicatingNodes, peer)
+							peerPoBinRep++
 						}
 					}
 				}
@@ -95,7 +134,7 @@ func Check(c bee.Cluster, o Options) (err error) {
 				return errPullSync
 			}
 
-			fmt.Printf("Chunk should be on %d nodes. %d within depth\n", len(replicatingNodes), nnRep)
+			fmt.Printf("Chunk should be on %d nodes. %d within depth, %d outside\n", len(replicatingNodes), nnRep, peerPoBinRep)
 			for _, n := range replicatingNodes {
 				ni := findIndex(overlays, n)
 				var (

--- a/pkg/check/pullsync/pullsync.go
+++ b/pkg/check/pullsync/pullsync.go
@@ -56,7 +56,7 @@ func Check(c bee.Cluster, o Options) (err error) {
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
-			addr, err := c.Nodes[i].UploadChunk(ctx, chunk, api.UploadOptions{Pin: false})
+			addr, err := chunk.Address(), c.Nodes[i].UploadChunk(ctx, &chunk, api.UploadOptions{Pin: false})
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}

--- a/pkg/check/pullsync/pullsync.go
+++ b/pkg/check/pullsync/pullsync.go
@@ -43,7 +43,7 @@ func Check(c bee.Cluster, o Options) (err error) {
 		return err
 	}
 
-	for i := 1; i < o.UploadNodeCount; i++ {
+	for i := 0; i < o.UploadNodeCount; i++ {
 		for j := 0; j < o.ChunksPerNode; j++ {
 			var (
 				chunk            bee.Chunk
@@ -70,7 +70,6 @@ func Check(c bee.Cluster, o Options) (err error) {
 			}
 			index := findIndex(overlays, closest)
 			fmt.Printf("Upload node %d. Chunk: %d. Closest: %d %s\n", i, j, index, closest.String())
-			fmt.Printf("%d overlays: \n%v", len(overlays), overlays)
 			topology, err := c.Nodes[index].Topology(ctx)
 			if err != nil {
 				return fmt.Errorf("node %d: %w", index, err)
@@ -93,12 +92,6 @@ func Check(c bee.Cluster, o Options) (err error) {
 
 			if len(replicatingNodes) == 0 {
 				fmt.Printf("Upload node %d. Chunk: %d. Chunk does not have any designated replicators.\n", i, j)
-				topology, err := c.Nodes[index].Topology(ctx)
-				if err != nil {
-					panic(err)
-				}
-				fmt.Println(topology.Depth, topology.Bins)
-
 				return errPullSync
 			}
 

--- a/pkg/check/pullsync/pullsync.go
+++ b/pkg/check/pullsync/pullsync.go
@@ -147,25 +147,3 @@ func findIndex(overlays []swarm.Address, addr swarm.Address) int {
 	}
 	return -1
 }
-
-func closestNode(chunk swarm.Address, nodes []swarm.Address) (closest swarm.Address, err error) {
-	closest = nodes[0]
-	for _, a := range nodes[1:] {
-		dcmp, err := swarm.DistanceCmp(chunk.Bytes(), closest.Bytes(), a.Bytes())
-		if err != nil {
-			return swarm.Address{}, fmt.Errorf("find closest node: %w", err)
-		}
-		switch dcmp {
-		case 0:
-			// do nothing
-		case -1:
-			// current node is closer
-			closest = a
-		case 1:
-			// closest is already closer to chunk
-			// do nothing
-		}
-	}
-
-	return
-}

--- a/pkg/check/pullsync/pullsync.go
+++ b/pkg/check/pullsync/pullsync.go
@@ -56,12 +56,12 @@ func Check(c bee.Cluster, o Options) (err error) {
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
-			addr, err := c.Nodes[i].UploadBytes(ctx, chunk.Data(), api.UploadOptions{Pin: false})
+			err = c.Nodes[i].UploadChunk(ctx, &chunk, api.UploadOptions{Pin: false})
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
-			uploaderToChunkPo := swarm.Proximity(overlays[i].Bytes(), addr.Bytes())
-			fmt.Printf("Uploaded chunk %s\n", addr.String())
+			uploaderToChunkPo := swarm.Proximity(overlays[i].Bytes(), chunk.Address().Bytes())
+			fmt.Printf("Uploaded chunk %s\n", chunk.Address().String())
 
 			// check uploader and non-NN replication
 			uploaderTopology := topologies[i]
@@ -72,7 +72,7 @@ func Check(c bee.Cluster, o Options) (err error) {
 					pidx := findIndex(overlays, peer)
 					pivotTopology := topologies[pidx]
 					pivotDepth := pivotTopology.Depth
-					switch pivotPo := int(swarm.Proximity(addr.Bytes(), peer.Bytes())); {
+					switch pivotPo := int(swarm.Proximity(chunk.Address().Bytes(), peer.Bytes())); {
 					case pivotPo >= pivotDepth:
 						// chunk within replicating node depth
 						if findIndex(replicatingNodes, peer) == -1 {
@@ -102,7 +102,7 @@ func Check(c bee.Cluster, o Options) (err error) {
 			if err != nil {
 				return fmt.Errorf("node %d: %w", index, err)
 			}
-			po := swarm.Proximity(addr.Bytes(), closest.Bytes())
+			po := swarm.Proximity(chunk.Address().Bytes(), closest.Bytes())
 			for _, v := range topology.Bins {
 				for _, peer := range v.ConnectedPeers {
 					peer := peer
@@ -110,7 +110,7 @@ func Check(c bee.Cluster, o Options) (err error) {
 					pidx := findIndex(overlays, peer)
 					pivotTopology := topologies[pidx]
 					pivotDepth := pivotTopology.Depth
-					switch pivotPo := int(swarm.Proximity(addr.Bytes(), peer.Bytes())); {
+					switch pivotPo := int(swarm.Proximity(chunk.Address().Bytes(), peer.Bytes())); {
 					case pivotPo >= pivotDepth:
 						// chunk within replicating node depth
 						if findIndex(replicatingNodes, peer) == -1 {
@@ -144,27 +144,27 @@ func Check(c bee.Cluster, o Options) (err error) {
 
 				for t := 1; t < 5; t++ {
 					time.Sleep(2 * time.Duration(t) * time.Second)
-					synced, err = c.Nodes[ni].HasChunk(ctx, addr)
+					synced, err = c.Nodes[ni].HasChunk(ctx, chunk.Address())
 					if err != nil {
 						return fmt.Errorf("node %d: %w", ni, err)
 					}
 					if synced {
 						break
 					}
-					fmt.Printf("Upload node %d. Chunk %d not found on node. Upload node: %s Chunk: %s Pivot: %s. Retrying...\n", i, j, overlays[i].String(), addr.String(), n)
+					fmt.Printf("Upload node %d. Chunk %d not found on node. Upload node: %s Chunk: %s Pivot: %s. Retrying...\n", i, j, overlays[i].String(), chunk.Address().String(), n)
 				}
 				if !synced {
-					return fmt.Errorf("Upload node %d. Chunk %d not found on node. Upload node: %s Chunk: %s Pivot: %s", i, j, overlays[i].String(), addr.String(), n)
+					return fmt.Errorf("Upload node %d. Chunk %d not found on node. Upload node: %s Chunk: %s Pivot: %s", i, j, overlays[i].String(), chunk.Address().String(), n)
 				}
 			}
 
-			rf, err := c.GlobalReplicationFactor(ctx, addr)
+			rf, err := c.GlobalReplicationFactor(ctx, chunk.Address())
 			if err != nil {
 				return fmt.Errorf("replication factor: %w", err)
 			}
 
 			if rf < o.ReplicationFactorThreshold {
-				return fmt.Errorf("chunk %s has low replication factor. got %d want %d", addr.String(), rf, o.ReplicationFactorThreshold)
+				return fmt.Errorf("chunk %s has low replication factor. got %d want %d", chunk.Address().String(), rf, o.ReplicationFactorThreshold)
 			}
 			totalReplicationFactor += float64(rf)
 			fmt.Printf("Chunk replication factor %d\n", rf)

--- a/pkg/check/pushsync/pushsync.go
+++ b/pkg/check/pushsync/pushsync.go
@@ -57,7 +57,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 			}
 
 			t0 := time.Now()
-			addr, err := c.Nodes[i].UploadBytes(ctx, chunk.Data(), api.UploadOptions{Pin: false})
+			addr, err := c.Nodes[i].UploadChunk(ctx, chunk, api.UploadOptions{Pin: false})
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
@@ -250,7 +250,7 @@ func chunkStream(ctx context.Context, node bee.Node, rnd *rand.Rand, count int) 
 				return
 			}
 
-			if _, err := n.UploadBytes(ctx, chunk.Data(), api.UploadOptions{Pin: false}); err != nil {
+			if _, err := n.UploadChunk(ctx, chunk, api.UploadOptions{Pin: false}); err != nil {
 				chunkStream <- chunkStreamMsg{Index: i, Error: err}
 				return
 			}

--- a/pkg/check/pushsync/pushsync.go
+++ b/pkg/check/pushsync/pushsync.go
@@ -57,7 +57,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 			}
 
 			t0 := time.Now()
-			addr, err := c.Nodes[i].UploadChunk(ctx, chunk, api.UploadOptions{Pin: false})
+			addr, err := chunk.Address(), c.Nodes[i].UploadChunk(ctx, &chunk, api.UploadOptions{Pin: false})
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
@@ -250,7 +250,7 @@ func chunkStream(ctx context.Context, node bee.Node, rnd *rand.Rand, count int) 
 				return
 			}
 
-			if _, err := n.UploadChunk(ctx, chunk, api.UploadOptions{Pin: false}); err != nil {
+			if err := n.UploadChunk(ctx, &chunk, api.UploadOptions{Pin: false}); err != nil {
 				chunkStream <- chunkStreamMsg{Index: i, Error: err}
 				return
 			}

--- a/pkg/check/retrieval/retrieval.go
+++ b/pkg/check/retrieval/retrieval.go
@@ -53,7 +53,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 			}
 
 			t0 := time.Now()
-			addr, err := c.Nodes[i].UploadBytes(ctx, chunk.Data(), api.UploadOptions{Pin: false})
+			addr, err := c.Nodes[i].UploadChunk(ctx, chunk, api.UploadOptions{Pin: false})
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}

--- a/pkg/check/retrieval/retrieval.go
+++ b/pkg/check/retrieval/retrieval.go
@@ -53,30 +53,30 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 			}
 
 			t0 := time.Now()
-			addr, err := c.Nodes[i].UploadChunk(ctx, chunk, api.UploadOptions{Pin: false})
+			err = c.Nodes[i].UploadChunk(ctx, &chunk, api.UploadOptions{Pin: false})
 			if err != nil {
 				return fmt.Errorf("node %d: %w", i, err)
 			}
 			d0 := time.Since(t0)
 
 			uploadedCounter.WithLabelValues(overlays[i].String()).Inc()
-			uploadTimeGauge.WithLabelValues(overlays[i].String(), addr.String()).Set(d0.Seconds())
+			uploadTimeGauge.WithLabelValues(overlays[i].String(), chunk.Address().String()).Set(d0.Seconds())
 			uploadTimeHistogram.Observe(d0.Seconds())
 
 			t1 := time.Now()
-			data, err := c.Nodes[c.Size()-1].DownloadBytes(ctx, addr)
+			data, err := c.Nodes[c.Size()-1].DownloadBytes(ctx, chunk.Address())
 			if err != nil {
 				return fmt.Errorf("node %d: %w", c.Size()-1, err)
 			}
 			d1 := time.Since(t1)
 
 			downloadedCounter.WithLabelValues(overlays[i].String()).Inc()
-			downloadTimeGauge.WithLabelValues(overlays[i].String(), addr.String()).Set(d1.Seconds())
+			downloadTimeGauge.WithLabelValues(overlays[i].String(), chunk.Address().String()).Set(d1.Seconds())
 			downloadTimeHistogram.Observe(d1.Seconds())
 
 			if !bytes.Equal(chunk.Data(), data) {
 				notRetrievedCounter.WithLabelValues(overlays[i].String()).Inc()
-				fmt.Printf("Node %d. Chunk %d not retrieved successfully. Uploaded size: %d Downloaded size: %d Node: %s Chunk: %s\n", i, j, chunk.Size(), len(data), overlays[i].String(), addr.String())
+				fmt.Printf("Node %d. Chunk %d not retrieved successfully. Uploaded size: %d Downloaded size: %d Node: %s Chunk: %s\n", i, j, chunk.Size(), len(data), overlays[i].String(), chunk.Address().String())
 				if bytes.Contains(chunk.Data(), data) {
 					fmt.Printf("Downloaded data is subset of the uploaded data\n")
 				}
@@ -84,7 +84,7 @@ func Check(c bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (err
 			}
 
 			retrievedCounter.WithLabelValues(overlays[i].String()).Inc()
-			fmt.Printf("Node %d. Chunk %d retrieved successfully. Node: %s Chunk: %s\n", i, j, overlays[i].String(), addr.String())
+			fmt.Printf("Node %d. Chunk %d retrieved successfully. Node: %s Chunk: %s\n", i, j, overlays[i].String(), chunk.Address().String())
 
 			if pushMetrics {
 				if err := pusher.Push(); err != nil {


### PR DESCRIPTION
Identified a bug where we were uploading a chunk to the bytes api. Because when generating the chunk, the span is appended to the random generated bytes, the hash which was returned from the bytes API was different than the hash generated in the beekeeper tests, since bmt hash is calculated without the span in the actual data being hashed, and the bytes api treated the span data that was appended to the data as actual data, not span data, resulting in a different hash. So actually the data chunk that was uploaded had a different hash, but the checks inside the actual tests use `chunk.ClosestNode`, which correlates to the correct hash (which wasn't in fact uploaded correctly), resulting in incorrect assumptions, and chunks which are never found where they are supposed to be.