### PR TITLE
Add test for pinning that fetches remote chunks

### DIFF
--- a/cmd/beekeeper/cmd/check.go
+++ b/cmd/beekeeper/cmd/check.go
@@ -65,6 +65,7 @@ func (c *command) initCheckCmd() (err error) {
 	cmd.AddCommand(c.initCheckGc())
 	cmd.AddCommand(c.initCheckLocalPinningChunk())
 	cmd.AddCommand(c.initCheckLocalPinningBytes())
+	cmd.AddCommand(c.initCheckLocalPinningRemote())
 	cmd.AddCommand(c.initCheckPeerCount())
 	cmd.AddCommand(c.initCheckPingPong())
 	cmd.AddCommand(c.initCheckPullSync())

--- a/cmd/beekeeper/cmd/check_localpinning_remote.go
+++ b/cmd/beekeeper/cmd/check_localpinning_remote.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ethersphere/beekeeper/pkg/bee"
+	"github.com/ethersphere/beekeeper/pkg/check/localpinning"
+	"github.com/ethersphere/beekeeper/pkg/random"
+
+	"github.com/spf13/cobra"
+)
+
+func (c *command) initCheckLocalPinningRemote() *cobra.Command {
+	const (
+		optionNameDbCapacity = "db-capacity"
+		optionNameDivisor    = "capacity-divisor"
+		optionNameSeed       = "seed"
+	)
+
+	cmdBytes := &cobra.Command{
+		Use:   "pin-remote",
+		Short: "Checks that a node on the cluster pins remote chunks correctly.",
+		Long:  "Checks that a node on the cluster pins remote chunks correctly.",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			cluster := bee.NewCluster("bee", bee.ClusterOptions{
+				APIDomain:           c.config.GetString(optionNameAPIDomain),
+				APIInsecureTLS:      insecureTLSAPI,
+				APIScheme:           c.config.GetString(optionNameAPIScheme),
+				DebugAPIDomain:      c.config.GetString(optionNameDebugAPIDomain),
+				DebugAPIInsecureTLS: insecureTLSDebugAPI,
+				DebugAPIScheme:      c.config.GetString(optionNameDebugAPIScheme),
+				Namespace:           c.config.GetString(optionNameNamespace),
+				DisableNamespace:    disableNamespace,
+			})
+
+			ngOptions := newDefaultNodeGroupOptions()
+			cluster.AddNodeGroup("nodes", *ngOptions)
+			ng := cluster.NodeGroup("nodes")
+
+			for i := 0; i < c.config.GetInt(optionNameNodeCount); i++ {
+				if err := ng.AddNode(fmt.Sprintf("bee-%d", i)); err != nil {
+					return fmt.Errorf("adding node bee-%d: %s", i, err)
+				}
+			}
+
+			var seed int64
+			if cmd.Flags().Changed("seed") {
+				seed = c.config.GetInt64(optionNameSeed)
+			} else {
+				seed = random.Int64()
+			}
+
+			return localpinning.CheckRemoteChunksFound(cluster, localpinning.Options{
+				NodeGroup:        "nodes",
+				StoreSize:        c.config.GetInt(optionNameDbCapacity),
+				StoreSizeDivisor: c.config.GetInt(optionNameDivisor),
+				Seed:             seed,
+			})
+		},
+		PreRunE: c.checkPreRunE,
+	}
+
+	cmdBytes.Flags().Int(optionNameDbCapacity, 8000, "DB capacity in chunks")
+	cmdBytes.Flags().Int(optionNameDivisor, 3, "divide store size by which value when uploading bytes")
+	cmdBytes.Flags().Int64P(optionNameSeed, "s", 0, "seed for generating files; if not set, will be random")
+	return cmdBytes
+}

--- a/cmd/beekeeper/cmd/check_localpinning_remote.go
+++ b/cmd/beekeeper/cmd/check_localpinning_remote.go
@@ -61,7 +61,7 @@ func (c *command) initCheckLocalPinningRemote() *cobra.Command {
 		PreRunE: c.checkPreRunE,
 	}
 
-	cmdBytes.Flags().Int(optionNameDbCapacity, 8000, "DB capacity in chunks")
+	cmdBytes.Flags().Int(optionNameDbCapacity, 1000, "DB capacity in chunks")
 	cmdBytes.Flags().Int(optionNameDivisor, 3, "divide store size by which value when uploading bytes")
 	cmdBytes.Flags().Int64P(optionNameSeed, "s", 0, "seed for generating files; if not set, will be random")
 	return cmdBytes

--- a/pkg/bee/node.go
+++ b/pkg/bee/node.go
@@ -154,6 +154,11 @@ func (c *Client) HasChunk(ctx context.Context, a swarm.Address) (bool, error) {
 	return c.debug.Node.HasChunk(ctx, a)
 }
 
+// RemoveChunkWithAddress removes chunk from the node
+func (c *Client) RemoveChunkWithAddress(ctx context.Context, a swarm.Address) error {
+	return c.debug.Node.RemoveChunk(ctx, a)
+}
+
 // Overlay returns node's overlay address
 func (c *Client) Overlay(ctx context.Context) (swarm.Address, error) {
 	a, err := c.debug.Node.Addresses(ctx)
@@ -223,6 +228,11 @@ func (c *Client) PinnedChunks(ctx context.Context) (PinnedChunks, error) {
 	}
 
 	return r, nil
+}
+
+// PinBytes returns true/false if bytes pinning is successful
+func (c *Client) PinBytes(ctx context.Context, a swarm.Address) (bool, error) {
+	return c.api.Pinning.PinBytes(ctx, a)
 }
 
 // Ping pings other node

--- a/pkg/bee/node.go
+++ b/pkg/bee/node.go
@@ -184,7 +184,7 @@ func (c *Client) Peers(ctx context.Context) (peers []swarm.Address, err error) {
 }
 
 // PinChunk returns true/false if chunk pinning is successful
-func (c *Client) PinChunk(ctx context.Context, a swarm.Address) (bool, error) {
+func (c *Client) PinChunk(ctx context.Context, a swarm.Address) error {
 	return c.api.Pinning.PinChunk(ctx, a)
 }
 
@@ -231,7 +231,7 @@ func (c *Client) PinnedChunks(ctx context.Context) (PinnedChunks, error) {
 }
 
 // PinBytes returns true/false if bytes pinning is successful
-func (c *Client) PinBytes(ctx context.Context, a swarm.Address) (bool, error) {
+func (c *Client) PinBytes(ctx context.Context, a swarm.Address) error {
 	return c.api.Pinning.PinBytes(ctx, a)
 }
 
@@ -387,7 +387,7 @@ func (c *Client) Underlay(ctx context.Context) ([]string, error) {
 }
 
 // UnpinChunk returns true/false if chunk unpinning is successful
-func (c *Client) UnpinChunk(ctx context.Context, a swarm.Address) (bool, error) {
+func (c *Client) UnpinChunk(ctx context.Context, a swarm.Address) error {
 	return c.api.Pinning.UnpinChunk(ctx, a)
 }
 

--- a/pkg/beeclient/api/pinning.go
+++ b/pkg/beeclient/api/pinning.go
@@ -66,3 +66,105 @@ func (p *PinningService) UnpinChunk(ctx context.Context, a swarm.Address) (bool,
 
 	return true, nil
 }
+
+// PinBytes pins chunks for bytes upload
+func (p *PinningService) PinBytes(ctx context.Context, a swarm.Address) (bool, error) {
+	resp := struct {
+		Message string `json:"message,omitempty"`
+		Code    int    `json:"code,omitempty"`
+	}{}
+
+	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/bytes/"+a.String(), nil, &resp)
+	if err == ErrNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// UnpinBytes unpins chunks for bytes upload
+func (p *PinningService) UnpinBytes(ctx context.Context, a swarm.Address) (bool, error) {
+	resp := struct {
+		Message string `json:"message,omitempty"`
+		Code    int    `json:"code,omitempty"`
+	}{}
+
+	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/bytes/"+a.String(), nil, &resp)
+	if err == ErrNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// PinFiles pins chunks for files upload
+func (p *PinningService) PinFiles(ctx context.Context, a swarm.Address) (bool, error) {
+	resp := struct {
+		Message string `json:"message,omitempty"`
+		Code    int    `json:"code,omitempty"`
+	}{}
+
+	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/files/"+a.String(), nil, &resp)
+	if err == ErrNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// UnpinFiles unpins chunks for files upload
+func (p *PinningService) UnpinFiles(ctx context.Context, a swarm.Address) (bool, error) {
+	resp := struct {
+		Message string `json:"message,omitempty"`
+		Code    int    `json:"code,omitempty"`
+	}{}
+
+	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/files/"+a.String(), nil, &resp)
+	if err == ErrNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// PinBzz pins chunks for bzz upload
+func (p *PinningService) PinBzz(ctx context.Context, a swarm.Address) (bool, error) {
+	resp := struct {
+		Message string `json:"message,omitempty"`
+		Code    int    `json:"code,omitempty"`
+	}{}
+
+	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/bzz/"+a.String(), nil, &resp)
+	if err == ErrNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// UnpinBzz unpins chunks for bzz upload
+func (p *PinningService) UnpinBzz(ctx context.Context, a swarm.Address) (bool, error) {
+	resp := struct {
+		Message string `json:"message,omitempty"`
+		Code    int    `json:"code,omitempty"`
+	}{}
+
+	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/bzz/"+a.String(), nil, &resp)
+	if err == ErrNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/beeclient/api/pinning.go
+++ b/pkg/beeclient/api/pinning.go
@@ -11,20 +11,13 @@ import (
 type PinningService service
 
 // PinChunk pins chunk
-func (p *PinningService) PinChunk(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) PinChunk(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/chunks/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodPost, "/pin/chunks/"+a.String(), nil, &resp)
 }
 
 // PinnedChunk represents pinned chunk
@@ -51,120 +44,71 @@ func (p *PinningService) PinnedChunks(ctx context.Context) (resp PinnedChunks, e
 }
 
 // UnpinChunk unpins chunk
-func (p *PinningService) UnpinChunk(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) UnpinChunk(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/chunks/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodDelete, "/pin/chunks/"+a.String(), nil, &resp)
 }
 
 // PinBytes pins chunks for bytes upload
-func (p *PinningService) PinBytes(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) PinBytes(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/bytes/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodPost, "/pin/bytes/"+a.String(), nil, &resp)
 }
 
 // UnpinBytes unpins chunks for bytes upload
-func (p *PinningService) UnpinBytes(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) UnpinBytes(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/bytes/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodDelete, "/pin/bytes/"+a.String(), nil, &resp)
 }
 
 // PinFiles pins chunks for files upload
-func (p *PinningService) PinFiles(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) PinFiles(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/files/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodPost, "/pin/files/"+a.String(), nil, &resp)
 }
 
 // UnpinFiles unpins chunks for files upload
-func (p *PinningService) UnpinFiles(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) UnpinFiles(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/files/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodDelete, "/pin/files/"+a.String(), nil, &resp)
 }
 
 // PinBzz pins chunks for bzz upload
-func (p *PinningService) PinBzz(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) PinBzz(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/bzz/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodPost, "/pin/bzz/"+a.String(), nil, &resp)
 }
 
 // UnpinBzz unpins chunks for bzz upload
-func (p *PinningService) UnpinBzz(ctx context.Context, a swarm.Address) (bool, error) {
+func (p *PinningService) UnpinBzz(ctx context.Context, a swarm.Address) error {
 	resp := struct {
 		Message string `json:"message,omitempty"`
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/bzz/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return p.client.requestJSON(ctx, http.MethodDelete, "/pin/bzz/"+a.String(), nil, &resp)
 }

--- a/pkg/beeclient/api/pinning.go
+++ b/pkg/beeclient/api/pinning.go
@@ -17,7 +17,7 @@ func (p *PinningService) PinChunk(ctx context.Context, a swarm.Address) (bool, e
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodPost, "/pinning/chunks/"+a.String(), nil, &resp)
+	err := p.client.requestJSON(ctx, http.MethodPost, "/pin/chunks/"+a.String(), nil, &resp)
 	if err == ErrNotFound {
 		return false, nil
 	} else if err != nil {
@@ -35,7 +35,7 @@ type PinnedChunk struct {
 
 // PinnedChunk gets pinned chunk
 func (p *PinningService) PinnedChunk(ctx context.Context, a swarm.Address) (resp PinnedChunk, err error) {
-	err = p.client.requestJSON(ctx, http.MethodGet, "/pinning/chunks/"+a.String(), nil, &resp)
+	err = p.client.requestJSON(ctx, http.MethodGet, "/pin/chunks/"+a.String(), nil, &resp)
 	return
 }
 
@@ -46,7 +46,7 @@ type PinnedChunks struct {
 
 // PinnedChunks gets pinned chunks
 func (p *PinningService) PinnedChunks(ctx context.Context) (resp PinnedChunks, err error) {
-	err = p.client.requestJSON(ctx, http.MethodGet, "/pinning/chunks", nil, &resp)
+	err = p.client.requestJSON(ctx, http.MethodGet, "/pin/chunks", nil, &resp)
 	return
 }
 
@@ -57,7 +57,7 @@ func (p *PinningService) UnpinChunk(ctx context.Context, a swarm.Address) (bool,
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := p.client.requestJSON(ctx, http.MethodDelete, "/pinning/chunks/"+a.String(), nil, &resp)
+	err := p.client.requestJSON(ctx, http.MethodDelete, "/pin/chunks/"+a.String(), nil, &resp)
 	if err == ErrNotFound {
 		return false, nil
 	} else if err != nil {

--- a/pkg/beeclient/debugapi/node.go
+++ b/pkg/beeclient/debugapi/node.go
@@ -65,6 +65,23 @@ func (n *NodeService) HasChunk(ctx context.Context, a swarm.Address) (bool, erro
 	return true, nil
 }
 
+// RemoveChunk removes chunk from the node
+func (n *NodeService) RemoveChunk(ctx context.Context, a swarm.Address) error {
+	resp := struct {
+		Message string `json:"message,omitempty"`
+		Code    int    `json:"code,omitempty"`
+	}{}
+
+	err := n.client.requestJSON(ctx, http.MethodDelete, "/chunks/"+a.String(), nil, &resp)
+	if err == ErrNotFound {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Health represents node's health
 type Health struct {
 	Status string `json:"status"`

--- a/pkg/beeclient/debugapi/node.go
+++ b/pkg/beeclient/debugapi/node.go
@@ -72,14 +72,7 @@ func (n *NodeService) RemoveChunk(ctx context.Context, a swarm.Address) error {
 		Code    int    `json:"code,omitempty"`
 	}{}
 
-	err := n.client.requestJSON(ctx, http.MethodDelete, "/chunks/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	return nil
+	return n.client.requestJSON(ctx, http.MethodDelete, "/chunks/"+a.String(), nil, &resp)
 }
 
 // Health represents node's health

--- a/pkg/check/chunkrepair/chunkrepair.go
+++ b/pkg/check/chunkrepair/chunkrepair.go
@@ -230,16 +230,7 @@ func uploadAndPinChunkToNode(ctx context.Context, node *bee.Client, chunk *bee.C
 		return err
 	}
 
-	err = node.PinChunk(ctx, chunk.Address())
-	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return errors.New("could not pin chunk")
-		}
-
-		return err
-	}
-
-	return nil
+	return node.PinChunk(ctx, chunk.Address())
 }
 
 // deleteChunkFromAllNodes deletes a given chunk from al the nodes of the cluster.

--- a/pkg/check/chunkrepair/chunkrepair.go
+++ b/pkg/check/chunkrepair/chunkrepair.go
@@ -229,13 +229,16 @@ func uploadAndPinChunkToNode(ctx context.Context, node *bee.Client, chunk *bee.C
 	if err != nil {
 		return err
 	}
-	pinned, err := node.PinChunk(ctx, chunk.Address())
+
+	err = node.PinChunk(ctx, chunk.Address())
 	if err != nil {
+		if errors.Is(err, api.ErrNotFound) {
+			return errors.New("could not pin chunk")
+		}
+
 		return err
 	}
-	if !pinned {
-		return errors.New("could not pin chunk")
-	}
+
 	return nil
 }
 

--- a/pkg/check/localpinning/bytes_found.go
+++ b/pkg/check/localpinning/bytes_found.go
@@ -76,7 +76,7 @@ func CheckBytesFound(c *bee.Cluster, o Options) error {
 
 	// cleanup
 	for _, a := range addrs {
-		_, err := ng.Node(pivotNode).UnpinChunk(ctx, a)
+		err := ng.Node(pivotNode).UnpinChunk(ctx, a)
 		if err != nil {
 			return fmt.Errorf("cannot unpin chunk: %w", err)
 		}

--- a/pkg/check/localpinning/chunk_found.go
+++ b/pkg/check/localpinning/chunk_found.go
@@ -63,7 +63,7 @@ func CheckChunkFound(c *bee.Cluster, o Options) error {
 	}
 
 	// cleanup
-	_, err = ng.Node(pivotNode).UnpinChunk(ctx, chunk.Address())
+	err = ng.Node(pivotNode).UnpinChunk(ctx, chunk.Address())
 	if err != nil {
 		return fmt.Errorf("unpin chunk: %w", err)
 	}

--- a/pkg/check/localpinning/remote_chunks_found.go
+++ b/pkg/check/localpinning/remote_chunks_found.go
@@ -102,7 +102,11 @@ func CheckRemoteChunksFound(c *bee.Cluster, o Options) error {
 			}
 		}
 
-		fmt.Printf("Node %s: has %d (expected %d)\n", name, chunksCountAfterPin, len(addrs))
+		if len(addrs) != chunksCountAfterPin {
+			return fmt.Errorf("Node %s: has %d chunks (expected %d)", name, chunksCountAfterPin, len(addrs))
+		}
+
+		fmt.Printf("Node %s: has %d chunks (expected %d)\n", name, chunksCountAfterPin, len(addrs))
 	}
 
 	// cleanup

--- a/pkg/check/localpinning/remote_chunks_found.go
+++ b/pkg/check/localpinning/remote_chunks_found.go
@@ -83,13 +83,9 @@ func CheckRemoteChunksFound(c *bee.Cluster, o Options) error {
 
 		fmt.Printf("Node %s: pinning chunks\n", name)
 
-		completed, err := nodeClient.PinBytes(ctx, ref)
+		err := nodeClient.PinBytes(ctx, ref)
 		if err != nil {
 			return fmt.Errorf("node %s: pin bytes: %w", name, err)
-		}
-
-		if !completed {
-			return fmt.Errorf("node %s: failed to pin bytes", name)
 		}
 
 		fmt.Printf("Node %s: checking for chunks\n", name)
@@ -116,7 +112,7 @@ func CheckRemoteChunksFound(c *bee.Cluster, o Options) error {
 		nodeClient := ng.Node(name)
 
 		for _, a := range addrs {
-			_, err := nodeClient.UnpinChunk(ctx, a)
+			err := nodeClient.UnpinChunk(ctx, a)
 			if err != nil {
 				return fmt.Errorf("cannot unpin chunk: %w", err)
 			}

--- a/pkg/check/localpinning/remote_chunks_found.go
+++ b/pkg/check/localpinning/remote_chunks_found.go
@@ -128,7 +128,6 @@ func CheckRemoteChunksFound(c *bee.Cluster, o Options) error {
 				if err != nil {
 					return fmt.Errorf("cannot unpin chunk: %w", err)
 				}
-				// ng.Node(name).UnpinChunk(ctx, a)
 			}
 		}
 	}


### PR DESCRIPTION
relates to: [ethersphere/bee#571](https://github.com/ethersphere/bee/issues/571)

Adds `pin-remote` check that performs pinning of bytes upload and then checks all those chunks are present locally using debug API.

One partly unfortunate thing is that because of how the Bee operates, if there is too few nodes in the topology, it is possible that all of them will replicate all chunks between themselves. As an attempt to "combat" this, few changes were made:
1. number of chunks that are being generated for upload was increased to `8000`
2. timeout to wait for chunks replication is set to `15` seconds
3. there is "verification" step that queries each node for expected chunks, and only on the nodes that do not have all the chunks does it perform pinning
    - initial idea was to return an error if every node has all the chunks, however since that may make this test "flaky" single log line is written to note the fact
