### PR TITLE
dynamic kademlia: dont check self

### DIFF
--- a/pkg/check/kademlia/dynamic.go
+++ b/pkg/check/kademlia/dynamic.go
@@ -173,6 +173,9 @@ func allOverlays(t bee.ClusterTopologies) []swarm.Address {
 func nodesInDepth(d uint8, pivot swarm.Address, addrs []swarm.Address) []swarm.Address {
 	var addrsInDepth []swarm.Address
 	for _, addr := range addrs {
+		if addr.Equal(pivot) {
+			continue
+		}
 		if swarm.Proximity(pivot.Bytes(), addr.Bytes()) >= d {
 			addrsInDepth = append(addrsInDepth, addr)
 		}


### PR DESCRIPTION
fixes a bug where nodes would check connection to themselves since it satisfies the original check in `nodesInDepth`