### PR TITLE
add a test for cashouts

### DIFF
--- a/cmd/beekeeper/cmd/check.go
+++ b/cmd/beekeeper/cmd/check.go
@@ -74,6 +74,7 @@ func (c *command) initCheckCmd() (err error) {
 	cmd.AddCommand(c.initCheckPushSync())
 	cmd.AddCommand(c.initCheckRetrieval())
 	cmd.AddCommand(c.initCheckSettlements())
+	cmd.AddCommand(c.initCheckCashout())
 	cmd.AddCommand(c.initCheckChunkRepair())
 	cmd.AddCommand(c.initCheckManifest())
 	cmd.AddCommand(c.initCheckPing())

--- a/cmd/beekeeper/cmd/check_cashout.go
+++ b/cmd/beekeeper/cmd/check_cashout.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ethersphere/beekeeper/pkg/bee"
+	"github.com/ethersphere/beekeeper/pkg/check/cashout"
+
+	"github.com/spf13/cobra"
+)
+
+func (c *command) initCheckCashout() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cashout",
+		Short: "Executes cashout check",
+		Long:  `Executes cashout check.`,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			cluster := bee.NewCluster("bee", bee.ClusterOptions{
+				APIDomain:           c.config.GetString(optionNameAPIDomain),
+				APIInsecureTLS:      insecureTLSAPI,
+				APIScheme:           c.config.GetString(optionNameAPIScheme),
+				DebugAPIDomain:      c.config.GetString(optionNameDebugAPIDomain),
+				DebugAPIInsecureTLS: insecureTLSDebugAPI,
+				DebugAPIScheme:      c.config.GetString(optionNameDebugAPIScheme),
+				Namespace:           c.config.GetString(optionNameNamespace),
+				DisableNamespace:    disableNamespace,
+			})
+
+			ngOptions := newDefaultNodeGroupOptions()
+			cluster.AddNodeGroup("nodes", *ngOptions)
+			ng := cluster.NodeGroup("nodes")
+
+			for i := 0; i < c.config.GetInt(optionNameNodeCount); i++ {
+				if err := ng.AddNode(fmt.Sprintf("bee-%d", i), bee.NodeOptions{}); err != nil {
+					return fmt.Errorf("adding node bee-%d: %s", i, err)
+				}
+			}
+
+			return cashout.Check(cluster, cashout.Options{
+				NodeGroup: "nodes",
+			})
+		},
+		PreRunE: c.checkPreRunE,
+	}
+
+	return cmd
+}

--- a/pkg/beeclient/debugapi/node.go
+++ b/pkg/beeclient/debugapi/node.go
@@ -2,6 +2,7 @@ package debugapi
 
 import (
 	"context"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -136,6 +137,50 @@ type Settlements struct {
 // Settlements returns node's settlements with all peers
 func (n *NodeService) Settlements(ctx context.Context) (resp Settlements, err error) {
 	err = n.client.request(ctx, http.MethodGet, "/settlements", nil, &resp)
+	return
+}
+
+type Cheque struct {
+	Beneficiary string   `json:"beneficiary"`
+	Chequebook  string   `json:"chequebook"`
+	Payout      *big.Int `json:"payout"`
+}
+
+type CashoutStatusResult struct {
+	Recipient  string   `json:"recipient"`
+	LastPayout *big.Int `json:"lastPayout"`
+	Bounced    bool     `json:"bounced"`
+}
+
+type CashoutStatusResponse struct {
+	Peer            swarm.Address        `json:"peer"`
+	Cheque          *Cheque              `json:"lastCashedCheque"`
+	TransactionHash *string              `json:"transactionHash"`
+	Result          *CashoutStatusResult `json:"result"`
+	UncashedAmount  *big.Int             `json:"uncashedAmount"`
+}
+
+func (n *NodeService) CashoutStatus(ctx context.Context, a swarm.Address) (resp CashoutStatusResponse, err error) {
+	err = n.client.request(ctx, http.MethodGet, "/chequebook/cashout/"+a.String(), nil, &resp)
+	return
+}
+
+type TransactionHashResponse struct {
+	TransactionHash string `json:"transactionHash"`
+}
+
+func (n *NodeService) Cashout(ctx context.Context, a swarm.Address) (resp TransactionHashResponse, err error) {
+	err = n.client.request(ctx, http.MethodPost, "/chequebook/cashout/"+a.String(), nil, &resp)
+	return
+}
+
+type ChequebookBalanceResponse struct {
+	TotalBalance     *big.Int `json:"totalBalance"`
+	AvailableBalance *big.Int `json:"availableBalance"`
+}
+
+func (n *NodeService) ChequebookBalance(ctx context.Context) (resp ChequebookBalanceResponse, err error) {
+	err = n.client.request(ctx, http.MethodGet, "/chequebook/balance", nil, &resp)
 	return
 }
 

--- a/pkg/check/cashout/cashout.go
+++ b/pkg/check/cashout/cashout.go
@@ -1,0 +1,111 @@
+package cashout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/beekeeper/pkg/bee"
+)
+
+// Options represents settlements check options
+type Options struct {
+	NodeGroup string
+}
+
+type CashoutAction struct {
+	node            string
+	peer            swarm.Address
+	uncashedAmount  *big.Int
+	transactionHash string
+	oldBalance      *big.Int
+}
+
+// Check executes settlements check
+func Check(c *bee.Cluster, o Options) (err error) {
+	ctx := context.Background()
+
+	ng := c.NodeGroup(o.NodeGroup)
+
+	sortedNodes := ng.NodesSorted()
+	var actions []CashoutAction
+
+	for _, node := range sortedNodes {
+		settlements, err := ng.NodeClient(node).Settlements(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, peerSettlements := range settlements.Settlements {
+			if peerSettlements.Received > 0 {
+				peerOverlay, err := swarm.ParseHexAddress(peerSettlements.Peer)
+				if err != nil {
+					return err
+				}
+				cashoutStatus, err := ng.NodeClient(node).CashoutStatus(ctx, peerOverlay)
+				if err != nil {
+					return err
+				}
+
+				if cashoutStatus.UncashedAmount.Cmp(big.NewInt(0)) > 0 {
+					chequebookBalance, err := ng.NodeClient(node).ChequebookBalance(ctx)
+					if err != nil {
+						return err
+					}
+
+					txHash, err := ng.NodeClient(node).Cashout(ctx, peerOverlay)
+					if err != nil {
+						return err
+					}
+
+					actions = append(actions, CashoutAction{
+						node:            node,
+						peer:            peerOverlay,
+						uncashedAmount:  cashoutStatus.UncashedAmount,
+						transactionHash: txHash,
+						oldBalance:      chequebookBalance.TotalBalance,
+					})
+
+					fmt.Printf("cashing out for peer %s on %s in transaction %s\n", peerOverlay, node, txHash)
+				}
+			}
+		}
+	}
+
+LOOP:
+	for i := 0; i < 10; i++ {
+		time.Sleep(5 * time.Second)
+
+		for _, action := range actions {
+			cashoutStatus, err := ng.NodeClient(action.node).CashoutStatus(ctx, action.peer)
+			if err != nil {
+				return err
+			}
+
+			if cashoutStatus.Result == nil {
+				fmt.Printf("transaction %s not yet confirmed\n", action.transactionHash)
+				continue LOOP
+			}
+
+			if cashoutStatus.Result.Bounced {
+				return fmt.Errorf("bouncing cheque on %s from peer %s", action.node, action.peer)
+			}
+
+			chequebookBalance, err := ng.NodeClient(action.node).ChequebookBalance(ctx)
+			if err != nil {
+				return err
+			}
+
+			if action.oldBalance.Cmp(chequebookBalance.TotalBalance) == 0 {
+				return fmt.Errorf("chequebook balance not changed after cashout. was %d, now is %d", action.oldBalance, chequebookBalance.TotalBalance)
+			}
+		}
+
+		return nil
+	}
+
+	return errors.New("not all cashouts confirmed")
+}

--- a/scripts/suite.sh
+++ b/scripts/suite.sh
@@ -43,7 +43,12 @@ _balances() {
 
 _settlements() {
     echo "*** SETTLEMENTS ***"
-    "${BEEKEEPER_BIN}" check settlements --api-scheme http --debug-api-scheme http ${NAMESPACE_OPTION} --debug-api-domain "${DOMAIN}" --api-domain "${DOMAIN}" --node-count "${REPLICA}" --upload-node-count 10
+    "${BEEKEEPER_BIN}" check settlements --api-scheme http --debug-api-scheme http ${NAMESPACE_OPTION} --debug-api-domain "${DOMAIN}" --api-domain "${DOMAIN}" --node-count "${REPLICA}" -t 50000000000 --upload-node-count "${REPLICA}" --expect-settlements=false
+}
+
+_cashout() {
+    echo "*** CASHOUT ***"
+    "${BEEKEEPER_BIN}" check cashout --api-scheme http --debug-api-scheme http ${NAMESPACE_OPTION} --debug-api-domain "${DOMAIN}" --api-domain "${DOMAIN}" --node-count "${REPLICA}"
 }
 
 _pushsync() {
@@ -118,6 +123,12 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
                 ACTION="settlements"
                 shift
             ;;
+            
+#/   cashout      run cashout test
+            cashout)
+                ACTION="cashout"
+                shift
+            ;;
 #/   pushsync         run pushsync test
             pushsync)
                 ACTION="pushsync"
@@ -184,6 +195,9 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
     fi
     if [[ $ACTION == "settlements" ]] || [[ $ACTION == "all" ]]; then
         _settlements
+    fi
+    if [[ $ACTION == "cashout" ]] || [[ $ACTION == "all" ]]; then
+        _cashout
     fi
     if [[ $ACTION == "pushsync" ]] || [[ $ACTION == "all" ]]; then
         _pushsync


### PR DESCRIPTION
This adds a check to beekeeper to test cashout functionality which currently has no coverage in tests using an actual blockchain.

It cashes out all cheques with uncashed amounts and waits for the receipt to be available and verifies that the total balance of the node which cashes out does actually change (this is not guaranteed if the other node also has a cheque in the other direction with exactly the same amount but this should be incredibly unlikely). 
All cashout transactions happen in parallel (thus this is also testing the nonce manager) an it waits at most 50s for all of them to confirm (which should always be enough for the testing blockchain). If there are no cheques to cashout, the check simply passes without doing anything.