### PR TITLE
make delay in pushsync-chunks configurable

### DIFF
--- a/cmd/beekeeper/cmd/check_pushsync.go
+++ b/cmd/beekeeper/cmd/check_pushsync.go
@@ -88,6 +88,7 @@ and checks if chunks are synced to their closest nodes.`,
 					NodeGroup:       "nodes",
 					UploadNodeCount: c.config.GetInt(optionNameUploadNodeCount),
 					ChunksPerNode:   c.config.GetInt(optionNameChunksPerNode),
+					RetryDelay:      c.config.GetDuration(optionNameRetryDelay),
 					Seed:            seed,
 				})
 			}

--- a/pkg/check/pushsync/check_chunks.go
+++ b/pkg/check/pushsync/check_chunks.go
@@ -45,7 +45,7 @@ func CheckChunks(c *bee.Cluster, o Options) (err error) {
 				return fmt.Errorf("node %s: %w", nodeName, err)
 			}
 
-			time.Sleep(2 * time.Second)
+			time.Sleep(o.RetryDelay)
 			synced, err := ng.NodeClient(closestName).HasChunk(ctx, ref)
 			if err != nil {
 				return fmt.Errorf("node %s: %w", nodeName, err)


### PR DESCRIPTION
`RetryDelay` is used in pushsync-files but not in pushsync-chunks. This PR uses it in both cases.