### PR TITLE
fix retrieval test

### DIFF
--- a/pkg/check/retrieval/retrieval.go
+++ b/pkg/check/retrieval/retrieval.go
@@ -85,9 +85,7 @@ func Check(c *bee.Cluster, o Options, pusher *push.Pusher, pushMetrics bool) (er
 
 			t1 := time.Now()
 
-			client = clients[lastNodeName]
-
-			data, err := client.DownloadChunk(ctx, ref, "")
+			data, err := clients[lastNodeName].DownloadChunk(ctx, ref, "")
 			if err != nil {
 				return fmt.Errorf("node %s: %w", lastNodeName, err)
 			}


### PR DESCRIPTION
client has been overridden with a different client, resulting in the tests breaking due to stamp issuer not found