### PR TITLE
fix: new bigint serialization

### DIFF
--- a/pkg/bee/client.go
+++ b/pkg/bee/client.go
@@ -106,7 +106,7 @@ func (c *Client) Balance(ctx context.Context, a swarm.Address) (resp Balance, er
 	}
 
 	return Balance{
-		Balance: b.Balance,
+		Balance: b.Balance.Int64(),
 		Peer:    b.Peer,
 	}, nil
 }
@@ -125,7 +125,7 @@ func (c *Client) Balances(ctx context.Context) (resp Balances, err error) {
 
 	for _, b := range r.Balances {
 		resp.Balances = append(resp.Balances, Balance{
-			Balance: b.Balance,
+			Balance: b.Balance.Int64(),
 			Peer:    b.Peer,
 		})
 	}
@@ -282,8 +282,8 @@ func (c *Client) RemoveChunk(ctx context.Context, a swarm.Address) error {
 // Settlement represents node's settlement with peer
 type Settlement struct {
 	Peer     string
-	Received int
-	Sent     int
+	Received int64
+	Sent     int64
 }
 
 // Settlement returns node's settlement with a given peer
@@ -295,8 +295,8 @@ func (c *Client) Settlement(ctx context.Context, a swarm.Address) (resp Settleme
 
 	return Settlement{
 		Peer:     b.Peer,
-		Received: b.Received,
-		Sent:     b.Sent,
+		Received: b.Received.Int.Int64(),
+		Sent:     b.Sent.Int.Int64(),
 	}, nil
 }
 
@@ -353,8 +353,8 @@ func (c *Client) UploadSOC(ctx context.Context, owner, ID, signature string, dat
 // Settlements represents Settlements's response
 type Settlements struct {
 	Settlements   []Settlement
-	TotalReceived int
-	TotalSent     int
+	TotalReceived int64
+	TotalSent     int64
 }
 
 // Settlements returns node's settlements
@@ -367,12 +367,12 @@ func (c *Client) Settlements(ctx context.Context) (resp Settlements, err error) 
 	for _, b := range r.Settlements {
 		resp.Settlements = append(resp.Settlements, Settlement{
 			Peer:     b.Peer,
-			Received: b.Received,
-			Sent:     b.Sent,
+			Received: b.Received.Int64(),
+			Sent:     b.Sent.Int64(),
 		})
 	}
-	resp.TotalReceived = r.TotalReceived
-	resp.TotalSent = r.TotalSent
+	resp.TotalReceived = r.TotalReceived.Int64()
+	resp.TotalSent = r.TotalSent.Int64()
 
 	return
 }
@@ -407,7 +407,7 @@ func (c *Client) CashoutStatus(ctx context.Context, a swarm.Address) (resp Casho
 	if r.Result != nil {
 		cashoutStatusResult = &CashoutStatusResult{
 			Recipient:  r.Result.Recipient,
-			LastPayout: r.Result.LastPayout,
+			LastPayout: r.Result.LastPayout.Int,
 			Bounced:    r.Result.Bounced,
 		}
 	}
@@ -417,11 +417,11 @@ func (c *Client) CashoutStatus(ctx context.Context, a swarm.Address) (resp Casho
 		Cheque: &Cheque{
 			Beneficiary: r.Cheque.Beneficiary,
 			Chequebook:  r.Cheque.Chequebook,
-			Payout:      r.Cheque.Payout,
+			Payout:      r.Cheque.Payout.Int,
 		},
 		TransactionHash: r.TransactionHash,
 		Result:          cashoutStatusResult,
-		UncashedAmount:  r.UncashedAmount,
+		UncashedAmount:  r.UncashedAmount.Int,
 	}, nil
 }
 
@@ -446,8 +446,8 @@ func (c *Client) ChequebookBalance(ctx context.Context) (resp ChequebookBalanceR
 	}
 
 	return ChequebookBalanceResponse{
-		TotalBalance:     r.TotalBalance,
-		AvailableBalance: r.AvailableBalance,
+		TotalBalance:     r.TotalBalance.Int,
+		AvailableBalance: r.AvailableBalance.Int,
 	}, nil
 }
 

--- a/pkg/bee/nodegroup.go
+++ b/pkg/bee/nodegroup.go
@@ -609,8 +609,8 @@ type NodeGroupSettlements map[string]map[string]SentReceived
 
 // SentReceived object
 type SentReceived struct {
-	Received int
-	Sent     int
+	Received int64
+	Sent     int64
 }
 
 // Settlements returns NodeGroupSettlements

--- a/pkg/beeclient/debugapi/node.go
+++ b/pkg/beeclient/debugapi/node.go
@@ -2,7 +2,7 @@ package debugapi
 
 import (
 	"context"
-	"math/big"
+	"github.com/ethersphere/beekeeper/pkg/bigint"
 	"net/http"
 	"time"
 
@@ -29,8 +29,8 @@ func (n *NodeService) Addresses(ctx context.Context) (resp Addresses, err error)
 
 // Balance represents node's balance with a peer
 type Balance struct {
-	Balance int64  `json:"balance"`
-	Peer    string `json:"peer"`
+	Balance *bigint.BigInt `json:"balance"`
+	Peer    string         `json:"peer"`
 }
 
 // Balance returns node's balance with a given peer
@@ -117,9 +117,9 @@ func (n *NodeService) Readiness(ctx context.Context) (resp Readiness, err error)
 
 // Settlement represents node's settlement with a peer
 type Settlement struct {
-	Peer     string `json:"peer"`
-	Received int    `json:"received"`
-	Sent     int    `json:"sent"`
+	Peer     string         `json:"peer"`
+	Received *bigint.BigInt `json:"received"`
+	Sent     *bigint.BigInt `json:"sent"`
 }
 
 // Settlement returns node's settlement with a given peer
@@ -130,9 +130,9 @@ func (n *NodeService) Settlement(ctx context.Context, a swarm.Address) (resp Set
 
 // Settlements represents node's settlements with all peers
 type Settlements struct {
-	Settlements   []Settlement `json:"settlements"`
-	TotalReceived int          `json:"totalreceived"`
-	TotalSent     int          `json:"totalsent"`
+	Settlements   []Settlement   `json:"settlements"`
+	TotalReceived *bigint.BigInt `json:"totalReceived"`
+	TotalSent     *bigint.BigInt `json:"totalSent"`
 }
 
 // Settlements returns node's settlements with all peers
@@ -142,15 +142,15 @@ func (n *NodeService) Settlements(ctx context.Context) (resp Settlements, err er
 }
 
 type Cheque struct {
-	Beneficiary string   `json:"beneficiary"`
-	Chequebook  string   `json:"chequebook"`
-	Payout      *big.Int `json:"payout"`
+	Beneficiary string         `json:"beneficiary"`
+	Chequebook  string         `json:"chequebook"`
+	Payout      *bigint.BigInt `json:"payout"`
 }
 
 type CashoutStatusResult struct {
-	Recipient  string   `json:"recipient"`
-	LastPayout *big.Int `json:"lastPayout"`
-	Bounced    bool     `json:"bounced"`
+	Recipient  string         `json:"recipient"`
+	LastPayout *bigint.BigInt `json:"lastPayout"`
+	Bounced    bool           `json:"bounced"`
 }
 
 type CashoutStatusResponse struct {
@@ -158,7 +158,7 @@ type CashoutStatusResponse struct {
 	Cheque          *Cheque              `json:"lastCashedCheque"`
 	TransactionHash *string              `json:"transactionHash"`
 	Result          *CashoutStatusResult `json:"result"`
-	UncashedAmount  *big.Int             `json:"uncashedAmount"`
+	UncashedAmount  *bigint.BigInt       `json:"uncashedAmount"`
 }
 
 func (n *NodeService) CashoutStatus(ctx context.Context, a swarm.Address) (resp CashoutStatusResponse, err error) {
@@ -176,8 +176,8 @@ func (n *NodeService) Cashout(ctx context.Context, a swarm.Address) (resp Transa
 }
 
 type ChequebookBalanceResponse struct {
-	TotalBalance     *big.Int `json:"totalBalance"`
-	AvailableBalance *big.Int `json:"availableBalance"`
+	TotalBalance     *bigint.BigInt `json:"totalBalance"`
+	AvailableBalance *bigint.BigInt `json:"availableBalance"`
 }
 
 func (n *NodeService) ChequebookBalance(ctx context.Context) (resp ChequebookBalanceResponse, err error) {

--- a/pkg/bigint/bigint.go
+++ b/pkg/bigint/bigint.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bigint
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+)
+
+type BigInt struct {
+	*big.Int
+}
+
+func (i *BigInt) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, i.String())), nil
+}
+
+func (i *BigInt) UnmarshalJSON(b []byte) error {
+	var val string
+	err := json.Unmarshal(b, &val)
+	if err != nil {
+		return err
+	}
+
+	if i.Int == nil {
+		i.Int = new(big.Int)
+	}
+
+	i.SetString(val, 10)
+
+	return nil
+}
+
+//Wrap wraps big.Int pointer into BigInt struct.
+func Wrap(i *big.Int) *BigInt {
+	return &BigInt{i}
+}

--- a/pkg/bigint/bigint_test.go
+++ b/pkg/bigint/bigint_test.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bigint_test
+
+import (
+	"encoding/json"
+	"github.com/ethersphere/bee/pkg/bigint"
+	"math"
+	"math/big"
+	"reflect"
+	"testing"
+)
+
+func TestMarshaling(t *testing.T) {
+	mar, err := json.Marshal(struct {
+		Bg *bigint.BigInt
+	}{
+		Bg: bigint.Wrap(new(big.Int).Mul(big.NewInt(math.MaxInt64), big.NewInt(math.MaxInt64))),
+	})
+	if err != nil {
+		t.Errorf("Marshaling failed")
+	}
+	if !reflect.DeepEqual(mar, []byte("{\"Bg\":\"85070591730234615847396907784232501249\"}")) {
+		t.Errorf("Wrongly marshaled data")
+	}
+}


### PR DESCRIPTION
This PR tackles the Bee BigInt serialization PR (https://github.com/ethersphere/bee-js/pull/290).

It compiles but I did not manage to actually run it as I am running on macOS and bee-local has problems with macOS :-( Could somebody please verify it functions as expected?

Also I have duplicated the `bigint` package from Bee as I don't really now how to include it from package as in the Bee it is not yet merged into master, but in order for it to be merged Beekeeper's tests needs to be working. Once it is merged then I can rework it to use the package directly from Bee.