### PR TITLE
retrieval simulation

### DIFF
--- a/cmd/beekeeper/cmd/check.go
+++ b/cmd/beekeeper/cmd/check.go
@@ -12,13 +12,14 @@ import (
 
 func (c *command) initCheckCmd() (err error) {
 	const (
-		optionNameClusterName    = "cluster-name"
-		optionNameCreateCluster  = "create-cluster"
-		optionNameChecks         = "checks"
-		optionNameMetricsEnabled = "metrics-enabled"
-		optionNameSeed           = "seed"
-		optionNameTimeout        = "timeout"
-		optionNameWithFunding    = "with-funding"
+		optionNameClusterName          = "cluster-name"
+		optionNameCreateCluster        = "create-cluster"
+		optionNameChecks               = "checks"
+		optionNameMetricsEnabled       = "metrics-enabled"
+		optionNameSeed                 = "seed"
+		optionNameTimeout              = "timeout"
+		optionNameWithFunding          = "with-funding"
+		optionNameMetricsPusherAddress = "metrics-pusher-address"
 		// TODO: optionNameStages         = "stages"
 
 	)
@@ -46,7 +47,7 @@ func (c *command) initCheckCmd() (err error) {
 			// set global config
 			checkGlobalConfig := config.CheckGlobalConfig{
 				MetricsEnabled: c.globalConfig.GetBool(optionNameMetricsEnabled),
-				MetricsPusher:  push.New("beekeeper", cfgCluster.GetNamespace()),
+				MetricsPusher:  push.New(c.globalConfig.GetString(optionNameMetricsPusherAddress), cfgCluster.GetNamespace()),
 				Seed:           c.globalConfig.GetInt64(optionNameSeed),
 			}
 
@@ -82,6 +83,7 @@ func (c *command) initCheckCmd() (err error) {
 	}
 
 	cmd.Flags().String(optionNameClusterName, "default", "cluster name")
+	cmd.Flags().String(optionNameMetricsPusherAddress, "beekeeper", "prometheus metrics pusher address")
 	cmd.Flags().Bool(optionNameCreateCluster, false, "creates cluster before executing checks")
 	cmd.Flags().StringSlice(optionNameChecks, []string{"pingpong"}, "list of checks to execute")
 	cmd.Flags().Bool(optionNameMetricsEnabled, false, "enable metrics")

--- a/cmd/beekeeper/cmd/check.go
+++ b/cmd/beekeeper/cmd/check.go
@@ -83,7 +83,7 @@ func (c *command) initCheckCmd() (err error) {
 	}
 
 	cmd.Flags().String(optionNameClusterName, "default", "cluster name")
-	cmd.Flags().String(optionNameMetricsPusherAddress, "beekeeper", "prometheus metrics pusher address")
+	cmd.Flags().String(optionNameMetricsPusherAddress, "pushgateway.dai.internal", "prometheus metrics pusher address")
 	cmd.Flags().Bool(optionNameCreateCluster, false, "creates cluster before executing checks")
 	cmd.Flags().StringSlice(optionNameChecks, []string{"pingpong"}, "list of checks to execute")
 	cmd.Flags().Bool(optionNameMetricsEnabled, false, "enable metrics")

--- a/cmd/beekeeper/cmd/simulate.go
+++ b/cmd/beekeeper/cmd/simulate.go
@@ -82,7 +82,7 @@ func (c *command) initSimulateCmd() (err error) {
 	}
 
 	cmd.Flags().String(optionNameClusterName, "default", "cluster name")
-	cmd.Flags().String(optionNameMetricsPusherAddress, "beekeeper", "prometheus metrics pusher address")
+	cmd.Flags().String(optionNameMetricsPusherAddress, "pushgateway.dai.internal", "prometheus metrics pusher address")
 	cmd.Flags().Bool(optionNameCreateCluster, false, "creates cluster before executing simulations")
 	cmd.Flags().StringSlice(optionNameSimulations, []string{"upload"}, "list of simulations to execute")
 	cmd.Flags().Bool(optionNameMetricsEnabled, false, "enable metrics")

--- a/cmd/beekeeper/cmd/simulate.go
+++ b/cmd/beekeeper/cmd/simulate.go
@@ -12,13 +12,14 @@ import (
 
 func (c *command) initSimulateCmd() (err error) {
 	const (
-		optionNameClusterName    = "cluster-name"
-		optionNameCreateCluster  = "create-cluster"
-		optionNameSimulations    = "simulations"
-		optionNameMetricsEnabled = "metrics-enabled"
-		optionNameSeed           = "seed"
-		optionNameTimeout        = "timeout"
-		optionNameWithFunding    = "with-funding"
+		optionNameClusterName          = "cluster-name"
+		optionNameCreateCluster        = "create-cluster"
+		optionNameSimulations          = "simulations"
+		optionNameMetricsEnabled       = "metrics-enabled"
+		optionNameSeed                 = "seed"
+		optionNameTimeout              = "timeout"
+		optionNameWithFunding          = "with-funding"
+		optionNameMetricsPusherAddress = "metrics-pusher-address"
 		// TODO: optionNameStages         = "stages"
 	)
 
@@ -45,7 +46,7 @@ func (c *command) initSimulateCmd() (err error) {
 			// set global config
 			simulationGlobalConfig := config.SimulationGlobalConfig{
 				MetricsEnabled: c.globalConfig.GetBool(optionNameMetricsEnabled),
-				MetricsPusher:  push.New("beekeeper", *cfgCluster.Namespace),
+				MetricsPusher:  push.New(c.globalConfig.GetString(optionNameMetricsPusherAddress), *cfgCluster.Namespace),
 				Seed:           c.globalConfig.GetInt64(optionNameSeed),
 			}
 
@@ -81,6 +82,7 @@ func (c *command) initSimulateCmd() (err error) {
 	}
 
 	cmd.Flags().String(optionNameClusterName, "default", "cluster name")
+	cmd.Flags().String(optionNameMetricsPusherAddress, "beekeeper", "prometheus metrics pusher address")
 	cmd.Flags().Bool(optionNameCreateCluster, false, "creates cluster before executing simulations")
 	cmd.Flags().StringSlice(optionNameSimulations, []string{"upload"}, "list of simulations to execute")
 	cmd.Flags().Bool(optionNameMetricsEnabled, false, "enable metrics")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -331,6 +331,17 @@ simulations:
       upload-node-percentage: 50
     timeout: 5m
     type: upload
+  retrieval:
+    options:
+      chunks-per-node: 1
+      metrics-enabled: true
+      postage-amount: 1
+      postage-depth: 16
+      postage-wait: 5s
+      upload-node-count: 1
+      upload-delay: 10s
+    timeout: 5m
+    type: retireval
 
 # stages defines stages for dynamic execution of checks and simulations
 stages:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -341,7 +341,7 @@ simulations:
       upload-node-count: 1
       upload-delay: 10s
     timeout: 5m
-    type: retireval
+    type: retrieval
 
 # stages defines stages for dynamic execution of checks and simulations
 stages:

--- a/pkg/config/bee.go
+++ b/pkg/config/bee.go
@@ -44,6 +44,7 @@ type BeeConfig struct {
 	Standalone                 *bool   `yaml:"standalone"`
 	SwapEnable                 *bool   `yaml:"swap-enable"`
 	SwapEndpoint               *string `yaml:"swap-endpoint"`
+	SwapDeploymentGasPrice     *string `yaml:"swap-deployment-gas-price"`
 	SwapFactoryAddress         *string `yaml:"swap-factory-address"`
 	SwapLegacyFactoryAddresses *string `yaml:"swap-legacy-factory-addresses"`
 	SwapInitialDeposit         *uint64 `yaml:"swap-initial-deposit"`

--- a/pkg/config/simulation.go
+++ b/pkg/config/simulation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethersphere/beekeeper/pkg/beekeeper"
 	"github.com/ethersphere/beekeeper/pkg/random"
+	"github.com/ethersphere/beekeeper/pkg/simulate/retrieval"
 	"github.com/ethersphere/beekeeper/pkg/simulate/upload"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"gopkg.in/yaml.v3"
@@ -50,6 +51,30 @@ var Simulations = map[string]SimulationType{
 				return nil, fmt.Errorf("decoding simulation %s options: %w", simulation.Type, err)
 			}
 			opts := upload.NewDefaultOptions()
+
+			if err := applySimulationConfig(simulationGlobalConfig, simulationOpts, &opts); err != nil {
+				return nil, fmt.Errorf("applying options: %w", err)
+			}
+
+			return opts, nil
+		},
+	},
+	"retrieval": {
+		NewAction: retrieval.NewSimulation,
+		NewOptions: func(simulationGlobalConfig SimulationGlobalConfig, simulation Simulation) (interface{}, error) {
+			simulationOpts := new(struct {
+				ChunksPerNode   *int           `yaml:"chunks-per-node"`
+				MetricsEnabled  *bool          `yaml:"metrics-enabled"`
+				PostageDepth    *uint64        `yaml:"postage-depth"`
+				PostageWait     *time.Duration `yaml:"postage-wait"`
+				Seed            *int64         `yaml:"seed"`
+				UploadNodeCount *int           `yaml:"upload-node-count"`
+				UploadDelay     *time.Duration `yaml:"upload-delay"`
+			})
+			if err := simulation.Options.Decode(simulationOpts); err != nil {
+				return nil, fmt.Errorf("decoding simulation %s options: %w", simulation.Type, err)
+			}
+			opts := retrieval.NewDefaultOptions()
 
 			if err := applySimulationConfig(simulationGlobalConfig, simulationOpts, &opts); err != nil {
 				return nil, fmt.Errorf("applying options: %w", err)

--- a/pkg/k8s/bee.go
+++ b/pkg/k8s/bee.go
@@ -92,6 +92,7 @@ type Config struct {
 	Standalone                 bool   // whether we want the node to start with no listen addresses for p2p
 	SwapEnable                 bool   // enable swap
 	SwapEndpoint               string // swap ethereum blockchain endpoint
+	SwapDeploymentGasPrice     string // gas price in wei to use for deployment and funding
 	SwapFactoryAddress         string // swap factory address
 	SwapLegacyFactoryAddresses string // swap legacy factory addresses
 	SwapInitialDeposit         uint64 // initial deposit if deploying a new chequebook

--- a/pkg/k8s/bee/helpers.go
+++ b/pkg/k8s/bee/helpers.go
@@ -44,6 +44,7 @@ resolver-options: {{.ResolverOptions}}
 standalone: {{.Standalone}}
 swap-enable: {{.SwapEnable}}
 swap-endpoint: {{.SwapEndpoint}}
+swap-deployment-gas-price: {{.SwapDeploymentGasPrice}}
 swap-factory-address: {{.SwapFactoryAddress}}
 swap-legacy-factory-addresses: {{.SwapLegacyFactoryAddresses}}
 swap-initial-deposit: {{.SwapInitialDeposit}}

--- a/pkg/k8s/bee/helpers.go
+++ b/pkg/k8s/bee/helpers.go
@@ -121,7 +121,7 @@ type setContainersOptions struct {
 
 func setContainers(o setContainersOptions) (c containers.Containers) {
 	c = append(c, containers.Container{
-		Name:            o.Name,
+		Name:            "bee",
 		Image:           o.Image,
 		ImagePullPolicy: o.ImagePullPolicy,
 		Command:         []string{"bee", "start", "--config=.bee.yaml"},

--- a/pkg/simulate/retrieval/metrics.go
+++ b/pkg/simulate/retrieval/metrics.go
@@ -64,7 +64,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			},
 			Name:    "chunk_upload_seconds",
 			Help:    "Chunk upload duration Histogram.",
-			Buckets: prometheus.LinearBuckets(0, 0.1, 10),
+			Buckets: []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
 	)
 	addCollector(uploadTimeHistogram)
@@ -106,7 +106,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			},
 			Name:    "chunk_download_seconds",
 			Help:    "Chunk download duration Histogram.",
-			Buckets: prometheus.LinearBuckets(0, 0.1, 10),
+			Buckets: []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
 	)
 	addCollector(downloadTimeHistogram)

--- a/pkg/simulate/retrieval/metrics.go
+++ b/pkg/simulate/retrieval/metrics.go
@@ -106,7 +106,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			ConstLabels: prometheus.Labels{
 				"cluster": clusterName,
 			},
-			Name: "chunks_not_downloadeded_count",
+			Name: "chunks_not_downloaded_count",
 			Help: "Number of chunks that has not been downloaded.",
 		},
 		[]string{"node"},

--- a/pkg/simulate/retrieval/metrics.go
+++ b/pkg/simulate/retrieval/metrics.go
@@ -1,0 +1,78 @@
+package retrieval
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	uploadedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunks_uploaded_count",
+			Help:      "Number of uploaded chunks.",
+		},
+		[]string{"node"},
+	)
+	uploadTimeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunk_upload_duration_seconds",
+			Help:      "Chunk upload duration Gauge.",
+		},
+		[]string{"node", "chunk"},
+	)
+	uploadTimeHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunk_upload_seconds",
+			Help:      "Chunk upload duration Histogram.",
+			Buckets:   prometheus.LinearBuckets(0, 0.1, 10),
+		},
+	)
+	downloadedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunks_downloaded_count",
+			Help:      "Number of downloaded chunks.",
+		},
+		[]string{"node"},
+	)
+	downloadTimeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunk_download_duration_seconds",
+			Help:      "Chunk download duration Gauge.",
+		},
+		[]string{"node", "chunk"},
+	)
+	downloadTimeHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunk_download_seconds",
+			Help:      "Chunk download duration Histogram.",
+			Buckets:   prometheus.LinearBuckets(0, 0.1, 10),
+		},
+	)
+	retrievedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunks_retrieved_count",
+			Help:      "Number of chunks that has been retrieved.",
+		},
+		[]string{"node"},
+	)
+	notRetrievedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "beekeeper",
+			Subsystem: "simulation_retrieval",
+			Name:      "chunks_not_retrieved_count",
+			Help:      "Number of chunks that has not been retrieved.",
+		},
+		[]string{"node"},
+	)
+)

--- a/pkg/simulate/retrieval/metrics.go
+++ b/pkg/simulate/retrieval/metrics.go
@@ -8,9 +8,11 @@ import (
 
 type metrics struct {
 	uploadedCounter       *prometheus.CounterVec
+	notUploadedCounter    *prometheus.CounterVec
 	uploadTimeGauge       *prometheus.GaugeVec
 	uploadTimeHistogram   prometheus.Histogram
 	downloadedCounter     *prometheus.CounterVec
+	notDownloadedCounter  *prometheus.CounterVec
 	downloadTimeGauge     *prometheus.GaugeVec
 	downloadTimeHistogram prometheus.Histogram
 	retrievedCounter      *prometheus.CounterVec
@@ -40,6 +42,20 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 		[]string{"node"},
 	)
 	addCollector(uploadedCounter)
+
+	notUploadedCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunks_not_uploaded_count",
+			Help: "Number of not uploaded chunks.",
+		},
+		[]string{"node"},
+	)
+	addCollector(notUploadedCounter)
 
 	uploadTimeGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -82,6 +98,20 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 		[]string{"node"},
 	)
 	addCollector(downloadedCounter)
+
+	notDownloadedCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunks_not_downloadeded_count",
+			Help: "Number of chunks that has not been downloaded.",
+		},
+		[]string{"node"},
+	)
+	addCollector(notDownloadedCounter)
 
 	downloadTimeGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -145,9 +175,11 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 
 	return metrics{
 		uploadedCounter:       uploadedCounter,
+		notUploadedCounter:    notUploadedCounter,
 		uploadTimeGauge:       uploadTimeGauge,
 		uploadTimeHistogram:   uploadTimeHistogram,
 		downloadedCounter:     downloadedCounter,
+		notDownloadedCounter:  notDownloadedCounter,
 		downloadTimeGauge:     downloadTimeGauge,
 		downloadTimeHistogram: downloadTimeHistogram,
 		retrievedCounter:      retrievedCounter,

--- a/pkg/simulate/retrieval/metrics.go
+++ b/pkg/simulate/retrieval/metrics.go
@@ -1,78 +1,156 @@
 package retrieval
 
-import "github.com/prometheus/client_golang/prometheus"
-
-var (
-	uploadedCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunks_uploaded_count",
-			Help:      "Number of uploaded chunks.",
-		},
-		[]string{"node"},
-	)
-	uploadTimeGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunk_upload_duration_seconds",
-			Help:      "Chunk upload duration Gauge.",
-		},
-		[]string{"node", "chunk"},
-	)
-	uploadTimeHistogram = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunk_upload_seconds",
-			Help:      "Chunk upload duration Histogram.",
-			Buckets:   prometheus.LinearBuckets(0, 0.1, 10),
-		},
-	)
-	downloadedCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunks_downloaded_count",
-			Help:      "Number of downloaded chunks.",
-		},
-		[]string{"node"},
-	)
-	downloadTimeGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunk_download_duration_seconds",
-			Help:      "Chunk download duration Gauge.",
-		},
-		[]string{"node", "chunk"},
-	)
-	downloadTimeHistogram = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunk_download_seconds",
-			Help:      "Chunk download duration Histogram.",
-			Buckets:   prometheus.LinearBuckets(0, 0.1, 10),
-		},
-	)
-	retrievedCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunks_retrieved_count",
-			Help:      "Number of chunks that has been retrieved.",
-		},
-		[]string{"node"},
-	)
-	notRetrievedCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "beekeeper",
-			Subsystem: "simulation_retrieval",
-			Name:      "chunks_not_retrieved_count",
-			Help:      "Number of chunks that has not been retrieved.",
-		},
-		[]string{"node"},
-	)
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/prometheus/common/expfmt"
 )
+
+type metrics struct {
+	uploadedCounter       *prometheus.CounterVec
+	uploadTimeGauge       *prometheus.GaugeVec
+	uploadTimeHistogram   prometheus.Histogram
+	downloadedCounter     *prometheus.CounterVec
+	downloadTimeGauge     *prometheus.GaugeVec
+	downloadTimeHistogram prometheus.Histogram
+	retrievedCounter      *prometheus.CounterVec
+	notRetrievedCounter   *prometheus.CounterVec
+}
+
+func newMetrics(clusterName string, pusher *push.Pusher) metrics {
+	namespace := "beekeeper"
+	subsystem := "simulation_retrieval"
+
+	addCollector := func(c prometheus.Collector) {
+		if pusher != nil {
+			pusher.Collector(c)
+		}
+	}
+
+	uploadedCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunks_uploaded_count",
+			Help: "Number of uploaded chunks.",
+		},
+		[]string{"node"},
+	)
+	addCollector(uploadedCounter)
+
+	uploadTimeGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunk_upload_duration_seconds",
+			Help: "Chunk upload duration Gauge.",
+		},
+		[]string{"node", "chunk"},
+	)
+	addCollector(uploadTimeGauge)
+
+	uploadTimeHistogram := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name:    "chunk_upload_seconds",
+			Help:    "Chunk upload duration Histogram.",
+			Buckets: prometheus.LinearBuckets(0, 0.1, 10),
+		},
+	)
+	addCollector(uploadTimeHistogram)
+
+	downloadedCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunks_downloaded_count",
+			Help: "Number of downloaded chunks.",
+		},
+		[]string{"node"},
+	)
+	addCollector(downloadedCounter)
+
+	downloadTimeGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunk_download_duration_seconds",
+			Help: "Chunk download duration Gauge.",
+		},
+		[]string{"node", "chunk"},
+	)
+	addCollector(downloadTimeGauge)
+
+	downloadTimeHistogram := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name:    "chunk_download_seconds",
+			Help:    "Chunk download duration Histogram.",
+			Buckets: prometheus.LinearBuckets(0, 0.1, 10),
+		},
+	)
+	addCollector(downloadTimeHistogram)
+
+	retrievedCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunks_retrieved_count",
+			Help: "Number of chunks that has been retrieved.",
+		},
+		[]string{"node"},
+	)
+	addCollector(retrievedCounter)
+
+	notRetrievedCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			ConstLabels: prometheus.Labels{
+				"cluster": clusterName,
+			},
+			Name: "chunks_not_retrieved_count",
+			Help: "Number of chunks that has not been retrieved.",
+		},
+		[]string{"node"},
+	)
+	addCollector(notRetrievedCounter)
+
+	if pusher != nil {
+		pusher.Format(expfmt.FmtText)
+	}
+
+	return metrics{
+		uploadedCounter:       uploadedCounter,
+		uploadTimeGauge:       uploadTimeGauge,
+		uploadTimeHistogram:   uploadTimeHistogram,
+		downloadedCounter:     downloadedCounter,
+		downloadTimeGauge:     downloadTimeGauge,
+		downloadTimeHistogram: downloadTimeHistogram,
+		retrievedCounter:      retrievedCounter,
+		notRetrievedCounter:   notRetrievedCounter,
+	}
+}

--- a/pkg/simulate/retrieval/retrieval.go
+++ b/pkg/simulate/retrieval/retrieval.go
@@ -104,6 +104,7 @@ func (s *Simulation) Run(ctx context.Context, cluster *bee.Cluster, opts interfa
 					fmt.Printf("error: node %s: %v\n", nodeName, err)
 					continue
 				}
+				fmt.Printf("Chunk %s uploaded successfully to node %s\n", chunk.Address().String(), overlays[nodeName].String())
 
 				metrics.uploadedCounter.WithLabelValues(overlays[nodeName].String()).Inc()
 				metrics.uploadTimeGauge.WithLabelValues(overlays[nodeName].String(), ref.String()).Set(d0.Seconds())
@@ -145,7 +146,7 @@ func (s *Simulation) Run(ctx context.Context, cluster *bee.Cluster, opts interfa
 				}
 
 				metrics.retrievedCounter.WithLabelValues(overlays[downloadNode].String()).Inc()
-				fmt.Printf("Node %s. Chunk %d retrieved successfully. Node: %s Chunk: %s\n", downloadNode, j, overlays[downloadNode].String(), chunk.Address().String())
+				fmt.Printf("Chunk %s retrieved successfully from node %s\n", chunk.Address().String(), overlays[downloadNode].String())
 
 				if o.MetricsPusher != nil {
 					if err := o.MetricsPusher.Push(); err != nil {

--- a/pkg/simulate/retrieval/retrieval.go
+++ b/pkg/simulate/retrieval/retrieval.go
@@ -1,0 +1,159 @@
+package retrieval
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethersphere/beekeeper/pkg/bee"
+	"github.com/ethersphere/beekeeper/pkg/beeclient/api"
+	"github.com/ethersphere/beekeeper/pkg/beekeeper"
+	"github.com/ethersphere/beekeeper/pkg/random"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/prometheus/common/expfmt"
+)
+
+// Options represents simulation options
+type Options struct {
+	ChunksPerNode   int // number of chunks to upload per node
+	MetricsPusher   *push.Pusher
+	PostageDepth    uint64
+	PostageWait     time.Duration
+	Seed            int64
+	UploadNodeCount int
+	UploadDelay     time.Duration
+}
+
+// NewDefaultOptions returns new default options
+func NewDefaultOptions() Options {
+	return Options{
+		ChunksPerNode:   1,
+		MetricsPusher:   nil,
+		PostageDepth:    16,
+		PostageWait:     5 * time.Second,
+		Seed:            random.Int64(),
+		UploadNodeCount: 1,
+		UploadDelay:     5 * time.Second,
+	}
+}
+
+// compile simulation whether Upload implements interface
+var _ beekeeper.Action = (*Simulation)(nil)
+
+// Simulation instance
+type Simulation struct{}
+
+// NewSimulation returns new upload simulation
+func NewSimulation() beekeeper.Action {
+	return &Simulation{}
+}
+
+// Run executes retrieval simulation
+func (s *Simulation) Run(ctx context.Context, cluster *bee.Cluster, opts interface{}) (err error) {
+	o, ok := opts.(Options)
+	if !ok {
+		return fmt.Errorf("invalid options type")
+	}
+
+	rnds := random.PseudoGenerators(o.Seed, o.UploadNodeCount)
+	fmt.Printf("Seed: %d\n", o.Seed)
+
+	if o.MetricsPusher != nil {
+		o.MetricsPusher.Collector(uploadedCounter)
+		o.MetricsPusher.Collector(uploadTimeGauge)
+		o.MetricsPusher.Collector(uploadTimeHistogram)
+		o.MetricsPusher.Collector(downloadedCounter)
+		o.MetricsPusher.Collector(downloadTimeGauge)
+		o.MetricsPusher.Collector(downloadTimeHistogram)
+		o.MetricsPusher.Collector(retrievedCounter)
+		o.MetricsPusher.Collector(notRetrievedCounter)
+		o.MetricsPusher.Format(expfmt.FmtText)
+	}
+
+	overlays, err := cluster.FlattenOverlays(ctx)
+	if err != nil {
+		return err
+	}
+	clients, err := cluster.NodesClients(ctx)
+	if err != nil {
+		return err
+	}
+
+	// continually upload chunk and download
+	for {
+		sortedNodes := cluster.NodeNames()
+		for i := 0; i < o.UploadNodeCount; i++ {
+
+			nodeName := sortedNodes[i]
+			client := clients[nodeName]
+
+			batchID, err := client.GetOrCreateBatch(ctx, o.PostageDepth, o.PostageWait)
+			if err != nil {
+				fmt.Printf("error: node %s: batch id %v\n", nodeName, err)
+				continue
+			}
+			fmt.Printf("node %s: batch id %s\n", nodeName, batchID)
+
+			for j := 0; j < o.ChunksPerNode; j++ {
+				chunk, err := bee.NewRandomChunk(rnds[i])
+				if err != nil {
+					fmt.Printf("error: node %s: %v\n", nodeName, err)
+					continue
+				}
+
+				t0 := time.Now()
+				ref, err := client.UploadChunk(ctx, chunk.Data(), api.UploadOptions{BatchID: batchID})
+				if err != nil {
+					fmt.Printf("error: node %s: %v\n", nodeName, err)
+					continue
+				}
+				d0 := time.Since(t0)
+
+				uploadedCounter.WithLabelValues(overlays[nodeName].String()).Inc()
+				uploadTimeGauge.WithLabelValues(overlays[nodeName].String(), ref.String()).Set(d0.Seconds())
+				uploadTimeHistogram.Observe(d0.Seconds())
+
+				t1 := time.Now()
+
+				// pick a random node to validate that the chunk is retrievable
+				downloadNode := sortedNodes[rnds[i].Intn(len(sortedNodes))]
+
+				data, err := clients[downloadNode].DownloadChunk(ctx, ref, "")
+				if err != nil {
+					fmt.Printf("error: node %s: %v\n", downloadNode, err)
+					continue
+				}
+				d1 := time.Since(t1)
+
+				downloadedCounter.WithLabelValues(overlays[nodeName].String()).Inc()
+				downloadTimeGauge.WithLabelValues(overlays[nodeName].String(), ref.String()).Set(d1.Seconds())
+				downloadTimeHistogram.Observe(d1.Seconds())
+
+				if !bytes.Equal(chunk.Data(), data) {
+					notRetrievedCounter.WithLabelValues(overlays[nodeName].String()).Inc()
+					fmt.Printf("Node %s. Chunk %d not retrieved successfully. Uploaded size: %d Downloaded size: %d Node: %s Chunk: %s\n", nodeName, j, chunk.Size(), len(data), overlays[nodeName].String(), ref.String())
+					if bytes.Contains(chunk.Data(), data) {
+						fmt.Printf("Downloaded data is subset of the uploaded data\n")
+					}
+					continue
+				}
+
+				retrievedCounter.WithLabelValues(overlays[nodeName].String()).Inc()
+				fmt.Printf("Node %s. Chunk %d retrieved successfully. Node: %s Chunk: %s\n", nodeName, j, overlays[nodeName].String(), chunk.Address().String())
+
+				if o.MetricsPusher != nil {
+					if err := o.MetricsPusher.Push(); err != nil {
+						fmt.Printf("node %s: %v\n", nodeName, err)
+					}
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(o.UploadDelay):
+		}
+	}
+}


### PR DESCRIPTION
This PR creates a chunk retrieval simulation, similar to the retrieval check where chunks are uploaded to nodes and downloaded to validate that they are retrievable.

The simulation is in form of a continuous set of uploads and downloads with configurable number of nodes, chunks per node and delay between uploads.

The result of the simulation are metrics beekeeper_simulation_retrieval_*.

There is no defined time for which the simulation is supposed to run. It runs until the context is canceled. In practice, until the beekeeper process is terminated.