### PR TITLE
Set new metrics label run for retrieval simulation

### DIFF
--- a/pkg/simulate/retrieval/metrics.go
+++ b/pkg/simulate/retrieval/metrics.go
@@ -19,7 +19,7 @@ type metrics struct {
 	notRetrievedCounter   *prometheus.CounterVec
 }
 
-func newMetrics(clusterName string, pusher *push.Pusher) metrics {
+func newMetrics(runID string, pusher *push.Pusher) metrics {
 	namespace := "beekeeper"
 	subsystem := "simulation_retrieval"
 
@@ -34,7 +34,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunks_uploaded_count",
 			Help: "Number of uploaded chunks.",
@@ -62,7 +62,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunk_upload_duration_seconds",
 			Help: "Chunk upload duration Gauge.",
@@ -76,7 +76,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name:    "chunk_upload_seconds",
 			Help:    "Chunk upload duration Histogram.",
@@ -90,7 +90,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunks_downloaded_count",
 			Help: "Number of downloaded chunks.",
@@ -118,7 +118,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunk_download_duration_seconds",
 			Help: "Chunk download duration Gauge.",
@@ -132,7 +132,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name:    "chunk_download_seconds",
 			Help:    "Chunk download duration Histogram.",
@@ -146,7 +146,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunks_retrieved_count",
 			Help: "Number of chunks that has been retrieved.",
@@ -160,7 +160,7 @@ func newMetrics(clusterName string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunks_not_retrieved_count",
 			Help: "Number of chunks that has not been retrieved.",

--- a/pkg/simulate/retrieval/metrics.go
+++ b/pkg/simulate/retrieval/metrics.go
@@ -48,7 +48,7 @@ func newMetrics(runID string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunks_not_uploaded_count",
 			Help: "Number of not uploaded chunks.",
@@ -104,7 +104,7 @@ func newMetrics(runID string, pusher *push.Pusher) metrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			ConstLabels: prometheus.Labels{
-				"cluster": clusterName,
+				"run": runID,
 			},
 			Name: "chunks_not_downloaded_count",
 			Help: "Number of chunks that has not been downloaded.",

--- a/pkg/simulate/retrieval/retrieval.go
+++ b/pkg/simulate/retrieval/retrieval.go
@@ -58,7 +58,7 @@ func (s *Simulation) Run(ctx context.Context, cluster *bee.Cluster, opts interfa
 	rnds := random.PseudoGenerators(o.Seed, o.UploadNodeCount)
 	fmt.Printf("Seed: %d\n", o.Seed)
 
-	metrics := newMetrics(cluster.Name(), o.MetricsPusher)
+	metrics := newMetrics(cluster.Name()+"-"+time.Now().UTC().Format("2006-01-02-15-04-05-000000000"), o.MetricsPusher)
 
 	overlays, err := cluster.FlattenOverlays(ctx)
 	if err != nil {


### PR DESCRIPTION
This PR changes the metrics label "cluster" to "run" which is unique up to the nano timestamp in order not to mix metrics on the same cluster between different simulation runs.