### PR TITLE
fix: wrong expect count

### DIFF
--- a/pkg/check/fullconnectivity/fullconnectivity.go
+++ b/pkg/check/fullconnectivity/fullconnectivity.go
@@ -64,10 +64,11 @@ func checkFullNodesConnectivity(ctx context.Context, cluster *bee.Cluster, skipN
 		return err
 	}
 
-	// clusterSize := cluster.Size()
-	expectedPeerCount := len(cluster.FullNodeNames()) - 1 // we expect to be connected to all full nodes except self
+	fullNodeNames := cluster.FullNodeNames()
+	fullNodeCount := len(fullNodeNames) - 1 // we expect to be connected to all full nodes except self
 
 	for group, v := range fullNodes {
+		expectedPeerCount := fullNodeCount
 		if isBootNode(group, bootNodes) {
 			expectedPeerCount = len(cluster.NodeNames()) - 1 // bootnodes are connected to all others
 		}


### PR DESCRIPTION
I made a mistake when setting expected peer count: if a bootnode would be picked first it would set the expected peer count to 4, even if for bee nodes it should stay 2.