### PR TITLE
feat: propagate message from bee http error responses

### DIFF
--- a/pkg/beeclient/api/api.go
+++ b/pkg/beeclient/api/api.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -219,54 +219,33 @@ func drain(r io.ReadCloser) {
 	}()
 }
 
-// responseErrorHandler returns an error based on the HTTP status code or nil if
-// the status code is from 200 to 299.
-func responseErrorHandler(r *http.Response) (err error) {
-	if r.StatusCode == http.StatusAccepted {
-		return ErrRecoveryInitiated
-	}
-	if r.StatusCode/100 == 2 {
-		return nil
-	}
-	switch r.StatusCode {
-	case http.StatusBadRequest:
-		return decodeBadRequest(r)
-	case http.StatusUnauthorized:
-		return ErrUnauthorized
-	case http.StatusForbidden:
-		return ErrForbidden
-	case http.StatusNotFound:
-		return ErrNotFound
-	case http.StatusTooManyRequests:
-		return ErrTooManyRequests
-	case http.StatusInternalServerError:
-		return ErrInternalServerError
-	case http.StatusServiceUnavailable:
-		return ErrServiceUnavailable
-	default:
-		return errors.New(strings.ToLower(r.Status))
-	}
+type messageResponse struct {
+	Message string `json:"message"`
 }
 
-// decodeBadRequest parses the body of HTTP response that contains a list of
-// errors as the result of bad request data.
-func decodeBadRequest(r *http.Response) (err error) {
-
-	type badRequestResponse struct {
-		Errors []string `json:"errors"`
+// responseErrorHandler returns an error based on the HTTP status code or nil if
+// the status code is from 200 to 299.
+// The error will include the message from standardized JSON-encoded error response
+// if it is not the same as the status text.
+func responseErrorHandler(r *http.Response) (err error) {
+	if r.StatusCode/100 == 2 {
+		// no error if response in 2xx range
+		return nil
 	}
 
-	if !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
-		return NewBadRequestError("bad request")
-	}
-	var e badRequestResponse
-	if err = json.NewDecoder(r.Body).Decode(&e); err != nil {
-		if err == io.EOF {
-			return NewBadRequestError("bad request")
+	var e messageResponse
+	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		if err = json.NewDecoder(r.Body).Decode(&e); err != nil && err != io.EOF {
+			return err
 		}
-		return err
 	}
-	return NewBadRequestError(e.Errors...)
+
+	err = NewHTTPStatusError(r.StatusCode)
+	// add message to the error if it is not already the same as the status text
+	if e.Message != "" && e.Message != http.StatusText(r.StatusCode) {
+		return fmt.Errorf("response message %q: status: %w", e.Message, err)
+	}
+	return err
 }
 
 // service is the base type for all API service providing the Client instance

--- a/pkg/beeclient/api/errors.go
+++ b/pkg/beeclient/api/errors.go
@@ -2,39 +2,34 @@ package api
 
 import (
 	"errors"
-	"strings"
+	"fmt"
+	"net/http"
 )
 
-// BadRequestError holds list of errors from http response that represent
-// invalid data submitted by the user.
-type BadRequestError struct {
-	errors []string
+// HTTPStatusError represents the error derived from the HTTP response status
+// code.
+type HTTPStatusError struct {
+	Code int
 }
 
-// NewBadRequestError constructs a new BadRequestError with provided errors.
-func NewBadRequestError(errors ...string) (err *BadRequestError) {
-	return &BadRequestError{
-		errors: errors,
+// NewHTTPStatusError creates a new instance of HTTPStatusError based on the
+// provided code.
+func NewHTTPStatusError(code int) *HTTPStatusError {
+	return &HTTPStatusError{
+		Code: code,
 	}
 }
 
-func (e *BadRequestError) Error() (s string) {
-	return strings.Join(e.errors, " ")
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("%d %s", e.Code, http.StatusText(e.Code))
 }
 
-// Errors returns a list of error messages.
-func (e *BadRequestError) Errors() (errs []string) {
-	return e.errors
+// IsHTTPStatusErrorCode return whether the error is HTTPStatusError with a
+// specific HTTP status code.
+func IsHTTPStatusErrorCode(err error, code int) bool {
+	var e *HTTPStatusError
+	if errors.As(err, &e) {
+		return e.Code == code
+	}
+	return false
 }
-
-// Errors that are returned by the API.
-var (
-	ErrUnauthorized        = errors.New("unauthorized")
-	ErrForbidden           = errors.New("forbidden")
-	ErrNotFound            = errors.New("not found")
-	ErrMethodNotAllowed    = errors.New("method not allowed")
-	ErrTooManyRequests     = errors.New("too many requests")
-	ErrInternalServerError = errors.New("internal server error")
-	ErrServiceUnavailable  = errors.New("service unavailable")
-	ErrRecoveryInitiated   = errors.New("try again later")
-)

--- a/pkg/beeclient/api/errors_test.go
+++ b/pkg/beeclient/api/errors_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsHTTPStatusErrorCode(t *testing.T) {
+	if ok := IsHTTPStatusErrorCode(NewHTTPStatusError(http.StatusBadGateway), http.StatusBadGateway); !ok {
+		t.Fatal("got false")
+	}
+	if ok := IsHTTPStatusErrorCode(NewHTTPStatusError(http.StatusBadGateway), http.StatusInternalServerError); ok {
+		t.Fatal("got true")
+	}
+	if ok := IsHTTPStatusErrorCode(nil, http.StatusTeapot); ok {
+		t.Fatal("got true")
+	}
+	if ok := IsHTTPStatusErrorCode(io.EOF, http.StatusTeapot); ok {
+		t.Fatal("got true")
+	}
+}
+
+func TestResponseErrorHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler http.Handler
+		err     error
+	}{
+		{
+			name:    "blank",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		},
+		{
+			name: "status ok",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		},
+		{
+			name: "status created",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+			}),
+		},
+		{
+			name: "status only",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			}),
+			err: NewHTTPStatusError(http.StatusBadRequest),
+		},
+		{
+			name: "status only 2",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}),
+			err: NewHTTPStatusError(http.StatusInternalServerError),
+		},
+		{
+			name: "no data",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Header().Set("Content-Type", contentType)
+			}),
+			err: NewHTTPStatusError(http.StatusInternalServerError),
+		},
+		{
+			name: "no message",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Header().Set("Content-Type", contentType)
+				_, _ = w.Write(encodeMessageResponse(t, ""))
+			}),
+			err: NewHTTPStatusError(http.StatusInternalServerError),
+		},
+		{
+			name: "custom message",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", contentType)
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write(encodeMessageResponse(t, "custom message"))
+			}),
+			err: fmt.Errorf("response message %q: status: %w", "custom message", NewHTTPStatusError(http.StatusInternalServerError)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			tc.handler.ServeHTTP(recorder, nil)
+
+			gotErr := responseErrorHandler(recorder.Result())
+
+			if tc.err == nil && gotErr == nil {
+				return // all fine
+			}
+
+			var e *HTTPStatusError
+			if !errors.As(gotErr, &e) {
+				t.Fatalf("got error %v, want %v", gotErr, tc.err)
+			} else if e.Code != recorder.Code {
+				t.Fatalf("got error code %v, want %v", e.Code, recorder.Code)
+			}
+
+			gotErrMessage := gotErr.Error()
+			wantErrMessage := tc.err.Error()
+			if gotErrMessage != wantErrMessage {
+				t.Fatalf("got error message %q, want %q", gotErrMessage, wantErrMessage)
+			}
+		})
+	}
+}
+
+func encodeMessageResponse(t *testing.T, message string) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(messageResponse{
+		Message: message,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return data
+}

--- a/pkg/beeclient/debugapi/debugapi.go
+++ b/pkg/beeclient/debugapi/debugapi.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -181,51 +181,33 @@ func drain(r io.ReadCloser) {
 	}()
 }
 
-// responseErrorHandler returns an error based on the HTTP status code or nil if
-// the status code is from 200 to 299.
-func responseErrorHandler(r *http.Response) (err error) {
-	if r.StatusCode/100 == 2 {
-		return nil
-	}
-	switch r.StatusCode {
-	case http.StatusBadRequest:
-		return decodeBadRequest(r)
-	case http.StatusUnauthorized:
-		return ErrUnauthorized
-	case http.StatusForbidden:
-		return ErrForbidden
-	case http.StatusNotFound:
-		return ErrNotFound
-	case http.StatusTooManyRequests:
-		return ErrTooManyRequests
-	case http.StatusInternalServerError:
-		return ErrInternalServerError
-	case http.StatusServiceUnavailable:
-		return ErrServiceUnavailable
-	default:
-		return errors.New(strings.ToLower(r.Status))
-	}
+type messageResponse struct {
+	Message string `json:"message"`
 }
 
-// decodeBadRequest parses the body of HTTP response that contains a list of
-// errors as the result of bad request data.
-func decodeBadRequest(r *http.Response) (err error) {
-
-	type badRequestResponse struct {
-		Errors []string `json:"errors"`
+// responseErrorHandler returns an error based on the HTTP status code or nil if
+// the status code is from 200 to 299.
+// The error will include the message from standardized JSON-encoded error response
+// if it is not the same as the status text.
+func responseErrorHandler(r *http.Response) (err error) {
+	if r.StatusCode/100 == 2 {
+		// no error if response in 2xx range
+		return nil
 	}
 
-	if !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
-		return NewBadRequestError("bad request")
-	}
-	var e badRequestResponse
-	if err = json.NewDecoder(r.Body).Decode(&e); err != nil {
-		if err == io.EOF {
-			return NewBadRequestError("bad request")
+	var e messageResponse
+	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		if err = json.NewDecoder(r.Body).Decode(&e); err != nil && err != io.EOF {
+			return err
 		}
-		return err
 	}
-	return NewBadRequestError(e.Errors...)
+
+	err = NewHTTPStatusError(r.StatusCode)
+	// add message to the error if it is not already the same as the status text
+	if e.Message != "" && e.Message != http.StatusText(r.StatusCode) {
+		return fmt.Errorf("response message %q: status: %w", e.Message, err)
+	}
+	return err
 }
 
 // service is the base type for all API service providing the Client instance

--- a/pkg/beeclient/debugapi/errors.go
+++ b/pkg/beeclient/debugapi/errors.go
@@ -2,38 +2,34 @@ package debugapi
 
 import (
 	"errors"
-	"strings"
+	"fmt"
+	"net/http"
 )
 
-// BadRequestError holds list of errors from http response that represent
-// invalid data submitted by the user.
-type BadRequestError struct {
-	errors []string
+// HTTPStatusError represents the error derived from the HTTP response status
+// code.
+type HTTPStatusError struct {
+	Code int
 }
 
-// NewBadRequestError constructs a new BadRequestError with provided errors.
-func NewBadRequestError(errors ...string) (err *BadRequestError) {
-	return &BadRequestError{
-		errors: errors,
+// NewHTTPStatusError creates a new instance of HTTPStatusError based on the
+// provided code.
+func NewHTTPStatusError(code int) *HTTPStatusError {
+	return &HTTPStatusError{
+		Code: code,
 	}
 }
 
-func (e *BadRequestError) Error() (s string) {
-	return strings.Join(e.errors, " ")
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("%d %s", e.Code, http.StatusText(e.Code))
 }
 
-// Errors returns a list of error messages.
-func (e *BadRequestError) Errors() (errs []string) {
-	return e.errors
+// IsHTTPStatusErrorCode return whether the error is HTTPStatusError with a
+// specific HTTP status code.
+func IsHTTPStatusErrorCode(err error, code int) bool {
+	var e *HTTPStatusError
+	if errors.As(err, &e) {
+		return e.Code == code
+	}
+	return false
 }
-
-// Errors that are returned by the API.
-var (
-	ErrUnauthorized        = errors.New("unauthorized")
-	ErrForbidden           = errors.New("forbidden")
-	ErrNotFound            = errors.New("not found")
-	ErrMethodNotAllowed    = errors.New("method not allowed")
-	ErrTooManyRequests     = errors.New("too many requests")
-	ErrInternalServerError = errors.New("internal server error")
-	ErrServiceUnavailable  = errors.New("service unavailable")
-)

--- a/pkg/beeclient/debugapi/errors_test.go
+++ b/pkg/beeclient/debugapi/errors_test.go
@@ -1,0 +1,128 @@
+package debugapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsHTTPStatusErrorCode(t *testing.T) {
+	if ok := IsHTTPStatusErrorCode(NewHTTPStatusError(http.StatusBadGateway), http.StatusBadGateway); !ok {
+		t.Fatal("got false")
+	}
+	if ok := IsHTTPStatusErrorCode(NewHTTPStatusError(http.StatusBadGateway), http.StatusInternalServerError); ok {
+		t.Fatal("got true")
+	}
+	if ok := IsHTTPStatusErrorCode(nil, http.StatusTeapot); ok {
+		t.Fatal("got true")
+	}
+	if ok := IsHTTPStatusErrorCode(io.EOF, http.StatusTeapot); ok {
+		t.Fatal("got true")
+	}
+}
+
+func TestResponseErrorHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler http.Handler
+		err     error
+	}{
+		{
+			name:    "blank",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		},
+		{
+			name: "status ok",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		},
+		{
+			name: "status created",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+			}),
+		},
+		{
+			name: "status only",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			}),
+			err: NewHTTPStatusError(http.StatusBadRequest),
+		},
+		{
+			name: "status only 2",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}),
+			err: NewHTTPStatusError(http.StatusInternalServerError),
+		},
+		{
+			name: "no data",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Header().Set("Content-Type", contentType)
+			}),
+			err: NewHTTPStatusError(http.StatusInternalServerError),
+		},
+		{
+			name: "no message",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Header().Set("Content-Type", contentType)
+				_, _ = w.Write(encodeMessageResponse(t, ""))
+			}),
+			err: NewHTTPStatusError(http.StatusInternalServerError),
+		},
+		{
+			name: "custom message",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", contentType)
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write(encodeMessageResponse(t, "custom message"))
+			}),
+			err: fmt.Errorf("response message %q: status: %w", "custom message", NewHTTPStatusError(http.StatusInternalServerError)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			tc.handler.ServeHTTP(recorder, nil)
+
+			gotErr := responseErrorHandler(recorder.Result())
+
+			if tc.err == nil && gotErr == nil {
+				return // all fine
+			}
+
+			var e *HTTPStatusError
+			if !errors.As(gotErr, &e) {
+				t.Fatalf("got error %v, want %v", gotErr, tc.err)
+			} else if e.Code != recorder.Code {
+				t.Fatalf("got error code %v, want %v", e.Code, recorder.Code)
+			}
+
+			gotErrMessage := gotErr.Error()
+			wantErrMessage := tc.err.Error()
+			if gotErrMessage != wantErrMessage {
+				t.Fatalf("got error message %q, want %q", gotErrMessage, wantErrMessage)
+			}
+		})
+	}
+}
+
+func encodeMessageResponse(t *testing.T, message string) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(messageResponse{
+		Message: message,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return data
+}

--- a/pkg/beeclient/debugapi/node.go
+++ b/pkg/beeclient/debugapi/node.go
@@ -59,7 +59,7 @@ func (n *NodeService) HasChunk(ctx context.Context, a swarm.Address) (bool, erro
 	}{}
 
 	err := n.client.requestJSON(ctx, http.MethodGet, "/chunks/"+a.String(), nil, &resp)
-	if err == ErrNotFound {
+	if IsHTTPStatusErrorCode(err, http.StatusNotFound) {
 		return false, nil
 	} else if err != nil {
 		return false, err


### PR DESCRIPTION
This PR changes how HTTP error responses are handled in `api` and `debugapi` packages. Bee sends a json-encoded body with `"message"` field which may contain some information about the error. It is sent for all responses, not just for the bad request and no `"errors"` field is sent. This PR adjusts the error handling to include additional information in the error message, to unify errors by their code, but does not deduplicate implementations into a single package, just adjusts similar code in both packages, as that should be a part of a different PR.