### PR TITLE
Set PodSecurityContext.FSGroupChangePolicy 

### DIFF
--- a/pkg/k8s/bee/bee.go
+++ b/pkg/k8s/bee/bee.go
@@ -331,6 +331,7 @@ func (c *Client) Create(ctx context.Context, o k8s.CreateOptions) (err error) {
 					}),
 					NodeSelector: o.NodeSelector,
 					PodSecurityContext: pod.PodSecurityContext{
+						FSGroupChangePolicy: "Always",
 						FSGroup: 999,
 					},
 					RestartPolicy:      o.RestartPolicy,


### PR DESCRIPTION
When creating a pod, an error is reported：

![image](https://user-images.githubusercontent.com/7932644/129521075-fd92f4fc-45a1-4322-bee3-7569f9a19e02.png)

Set PodSecurityContext.FSGroupChangePolicy as the default value: “Always”

![image](https://user-images.githubusercontent.com/7932644/129521259-95fb22c2-738e-4436-a9ed-f53fa1a4e53d.png)

Now it works:

![image](https://user-images.githubusercontent.com/7932644/129521440-0eff6e90-7829-4020-a2b6-fee202aff399.png)
