### PR TITLE
feat: add postage check

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -336,6 +336,14 @@ checks:
       content-size: 16384
       postage-amount: 1000
       postage-depth: 16
+  postage:
+    type: postage
+    timeout: 5m
+    options:
+      postage-amount: 1000
+      postage-depth: 16
+      postage-topup-amount: 100
+      postage-new-depth: 17
 
 # simulations defines simulations Beekeeper can execute against the cluster
 # type filed allows defining same simulation with different names and options 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -341,9 +341,9 @@ checks:
     timeout: 5m
     options:
       postage-amount: 1000
-      postage-depth: 16
+      postage-depth: 17
       postage-topup-amount: 100
-      postage-new-depth: 17
+      postage-new-depth: 18
 
 # simulations defines simulations Beekeeper can execute against the cluster
 # type filed allows defining same simulation with different names and options 

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -339,3 +339,11 @@ checks:
       content-size: 16384
       postage-amount: 1000
       postage-depth: 16
+  ci-postage:
+    type: postage
+    timeout: 5m
+    options:
+      postage-amount: 1000
+      postage-depth: 16
+      postage-topup-amount: 100
+      postage-new-depth: 17

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -344,6 +344,6 @@ checks:
     timeout: 5m
     options:
       postage-amount: 1000
-      postage-depth: 16
+      postage-depth: 17
       postage-topup-amount: 100
-      postage-new-depth: 17
+      postage-new-depth: 18

--- a/pkg/bee/client.go
+++ b/pkg/bee/client.go
@@ -379,6 +379,16 @@ func (c *Client) PostageBatches(ctx context.Context) ([]debugapi.PostageStampRes
 	return c.debug.Postage.PostageBatches(ctx)
 }
 
+// TopupPostageBatch tops up the given batch with the amount per chunk
+func (c *Client) TopUpPostageBatch(ctx context.Context, batchID string, amount int64, gasPrice string) error {
+	return c.debug.Postage.TopUpPostageBatch(ctx, batchID, amount, gasPrice)
+}
+
+// DilutePostageBatch dilutes the given batch by increasing the depth
+func (c *Client) DilutePostageBatch(ctx context.Context, batchID string, depth uint64, gasPrice string) error {
+	return c.debug.Postage.DilutePostageBatch(ctx, batchID, depth, gasPrice)
+}
+
 // ReserveState returns reserve radius, available capacity, inner and outer radiuses
 func (c *Client) ReserveState(ctx context.Context) (debugapi.ReserveState, error) {
 	return c.debug.Postage.ReserveState(ctx)

--- a/pkg/beeclient/debugapi/postage.go
+++ b/pkg/beeclient/debugapi/postage.go
@@ -33,7 +33,7 @@ type postageStampsResponse struct {
 	Stamps []PostageStampResponse `json:"stamps"`
 }
 
-// Sends a create postage request to a node that returns the bactchID
+// Sends a create postage request to a node that returns the batchID
 func (p *PostageService) CreatePostageBatch(ctx context.Context, amount int64, depth uint64, gasPrice, label string) (batchID string, err error) {
 	url := fmt.Sprintf("/stamps/%d/%d?label=%s", amount, depth, label)
 	var resp postageResponse
@@ -51,7 +51,7 @@ func (p *PostageService) CreatePostageBatch(ctx context.Context, amount int64, d
 	return resp.BatchID, err
 }
 
-// Sends a create postage request to a node that returns the bactchID
+// Sends a topup batch request to a node that returns the batchID
 func (p *PostageService) TopUpPostageBatch(ctx context.Context, batchID string, amount int64, gasPrice string) (err error) {
 	url := fmt.Sprintf("/stamps/topup/%s/%d", batchID, amount)
 	if gasPrice != "" {
@@ -62,7 +62,7 @@ func (p *PostageService) TopUpPostageBatch(ctx context.Context, batchID string, 
 	return p.client.request(ctx, http.MethodPatch, url, nil, nil)
 }
 
-// Sends a create postage request to a node that returns the bactchID
+// Sends a dilute batch request to a node that returns the batchID
 func (p *PostageService) DilutePostageBatch(ctx context.Context, batchID string, newDepth uint64, gasPrice string) (err error) {
 	url := fmt.Sprintf("/stamps/dilute/%s/%d", batchID, newDepth)
 	if gasPrice != "" {

--- a/pkg/beeclient/debugapi/postage.go
+++ b/pkg/beeclient/debugapi/postage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/ethersphere/beekeeper/pkg/bigint"
 )
@@ -53,7 +54,7 @@ func (p *PostageService) CreatePostageBatch(ctx context.Context, amount int64, d
 
 // Sends a topup batch request to a node that returns the batchID
 func (p *PostageService) TopUpPostageBatch(ctx context.Context, batchID string, amount int64, gasPrice string) (err error) {
-	url := fmt.Sprintf("/stamps/topup/%s/%d", batchID, amount)
+	url := fmt.Sprintf("/stamps/topup/%s/%d", url.PathEscape(batchID), amount)
 	if gasPrice != "" {
 		h := http.Header{}
 		h.Add("Gas-Price", gasPrice)
@@ -64,7 +65,7 @@ func (p *PostageService) TopUpPostageBatch(ctx context.Context, batchID string, 
 
 // Sends a dilute batch request to a node that returns the batchID
 func (p *PostageService) DilutePostageBatch(ctx context.Context, batchID string, newDepth uint64, gasPrice string) (err error) {
-	url := fmt.Sprintf("/stamps/dilute/%s/%d", batchID, newDepth)
+	url := fmt.Sprintf("/stamps/dilute/%s/%d", url.PathEscape(batchID), newDepth)
 	if gasPrice != "" {
 		h := http.Header{}
 		h.Add("Gas-Price", gasPrice)

--- a/pkg/beeclient/debugapi/postage.go
+++ b/pkg/beeclient/debugapi/postage.go
@@ -57,9 +57,9 @@ func (p *PostageService) TopUpPostageBatch(ctx context.Context, batchID string, 
 	if gasPrice != "" {
 		h := http.Header{}
 		h.Add("Gas-Price", gasPrice)
-		return p.client.requestWithHeader(ctx, http.MethodPost, url, h, nil, nil)
+		return p.client.requestWithHeader(ctx, http.MethodPatch, url, h, nil, nil)
 	}
-	return p.client.request(ctx, http.MethodPost, url, nil, nil)
+	return p.client.request(ctx, http.MethodPatch, url, nil, nil)
 }
 
 // Sends a create postage request to a node that returns the bactchID
@@ -68,9 +68,9 @@ func (p *PostageService) DilutePostageBatch(ctx context.Context, batchID string,
 	if gasPrice != "" {
 		h := http.Header{}
 		h.Add("Gas-Price", gasPrice)
-		return p.client.requestWithHeader(ctx, http.MethodPost, url, h, nil, nil)
+		return p.client.requestWithHeader(ctx, http.MethodPatch, url, h, nil, nil)
 	}
-	return p.client.request(ctx, http.MethodPost, url, nil, nil)
+	return p.client.request(ctx, http.MethodPatch, url, nil, nil)
 }
 
 // Fetches the list postage stamp batches

--- a/pkg/beeclient/debugapi/postage.go
+++ b/pkg/beeclient/debugapi/postage.go
@@ -51,6 +51,28 @@ func (p *PostageService) CreatePostageBatch(ctx context.Context, amount int64, d
 	return resp.BatchID, err
 }
 
+// Sends a create postage request to a node that returns the bactchID
+func (p *PostageService) TopUpPostageBatch(ctx context.Context, batchID string, amount int64, gasPrice string) (err error) {
+	url := fmt.Sprintf("/stamps/topup/%s/%d", batchID, amount)
+	if gasPrice != "" {
+		h := http.Header{}
+		h.Add("Gas-Price", gasPrice)
+		return p.client.requestWithHeader(ctx, http.MethodPost, url, h, nil, nil)
+	}
+	return p.client.request(ctx, http.MethodPost, url, nil, nil)
+}
+
+// Sends a create postage request to a node that returns the bactchID
+func (p *PostageService) DilutePostageBatch(ctx context.Context, batchID string, newDepth uint64, gasPrice string) (err error) {
+	url := fmt.Sprintf("/stamps/dilute/%s/%d", batchID, newDepth)
+	if gasPrice != "" {
+		h := http.Header{}
+		h.Add("Gas-Price", gasPrice)
+		return p.client.requestWithHeader(ctx, http.MethodPost, url, h, nil, nil)
+	}
+	return p.client.request(ctx, http.MethodPost, url, nil, nil)
+}
+
 // Fetches the list postage stamp batches
 func (p *PostageService) PostageBatches(ctx context.Context) ([]PostageStampResponse, error) {
 	var resp postageStampsResponse

--- a/pkg/check/postage/postage.go
+++ b/pkg/check/postage/postage.go
@@ -1,0 +1,194 @@
+package postage
+
+import (
+	"context"
+	"fmt"
+	mbig "math/big"
+	"time"
+
+	"github.com/ethersphere/beekeeper/pkg/bee"
+	"github.com/ethersphere/beekeeper/pkg/beekeeper"
+)
+
+// Options represents check options
+type Options struct {
+	GasPrice           string
+	PostageAmount      int64
+	PostageTopupAmount int64
+	PostageDepth       uint64
+	PostageNewDepth    uint64
+	PostageLabel       string
+	PostageWait        time.Duration
+	NodeCount          int
+}
+
+// NewDefaultOptions returns new default options
+func NewDefaultOptions() Options {
+	return Options{
+		GasPrice:           "",
+		PostageAmount:      1000,
+		PostageTopupAmount: 100,
+		PostageDepth:       16,
+		PostageNewDepth:    17,
+		PostageLabel:       "test-label",
+		PostageWait:        5 * time.Second,
+		NodeCount:          1,
+	}
+}
+
+// compile check whether Check implements interface
+var _ beekeeper.Action = (*Check)(nil)
+
+// Check instance
+type Check struct{}
+
+// NewCheck returns new check
+func NewCheck() beekeeper.Action {
+	return &Check{}
+}
+
+func (c *Check) Run(ctx context.Context, cluster *bee.Cluster, opts interface{}) (err error) {
+	o, ok := opts.(Options)
+	if !ok {
+		return fmt.Errorf("invalid options type")
+	}
+
+	clients, err := cluster.NodesClients(ctx)
+	if err != nil {
+		return err
+	}
+
+	sortedNodes := cluster.NodeNames()
+	node := sortedNodes[0]
+
+	client := clients[node]
+
+	batchID, err := client.CreatePostageBatch(ctx, o.PostageAmount, o.PostageDepth, o.GasPrice, o.PostageLabel, false)
+	if err != nil {
+		return fmt.Errorf("node %s: batch id %w", node, err)
+	}
+	time.Sleep(o.PostageWait)
+
+	batches, err := client.PostageBatches(ctx)
+	if err != nil {
+		return fmt.Errorf("failed getting postage batches %w", err)
+	}
+
+	currentValue := mbig.NewInt(0).Mul(mbig.NewInt(o.PostageAmount), mbig.NewInt(1<<o.PostageDepth))
+
+	found := false
+	for _, v := range batches {
+		if v.BatchID == batchID {
+			found = true
+			if v.Amount.Cmp(currentValue) != 0 {
+				return fmt.Errorf(
+					"invalid batch amount expected %d got %d, batch %s",
+					currentValue.Int64(),
+					v.Amount.Int64(),
+					batchID,
+				)
+			}
+			if v.Depth != uint8(o.PostageDepth) {
+				return fmt.Errorf(
+					"invalid batch amount expected %d got %d, batch %s",
+					o.PostageDepth,
+					v.Depth,
+					batchID,
+				)
+			}
+		}
+	}
+	if !found {
+		return fmt.Errorf("cannot find batch %s", batchID)
+	}
+
+	fmt.Printf("node %s: created new batch id %s\n", node, batchID)
+
+	err = client.TopUpPostageBatch(ctx, batchID, o.PostageTopupAmount, o.GasPrice)
+	if err != nil {
+		return fmt.Errorf("failed topping up batch %s with amount %d gas %s: %w", batchID, o.PostageTopupAmount, o.GasPrice, err)
+	}
+	time.Sleep(o.PostageWait)
+
+	batches, err = client.PostageBatches(ctx)
+	if err != nil {
+		return fmt.Errorf("failed getting postage batches %w", err)
+	}
+
+	topupAmount := mbig.NewInt(o.PostageTopupAmount)
+
+	newValue := mbig.NewInt(0).Add(currentValue, mbig.NewInt(0).Mul(topupAmount, mbig.NewInt(int64(1<<o.PostageDepth))))
+
+	found = false
+	for _, v := range batches {
+		if v.BatchID == batchID {
+			found = true
+			if v.Amount.Cmp(newValue) != 0 {
+				return fmt.Errorf(
+					"invalid batch amount expected %d got %d, batch %s",
+					newValue.Int64(),
+					v.Amount.Int64(),
+					batchID,
+				)
+			}
+			if v.Depth != uint8(o.PostageDepth) {
+				return fmt.Errorf(
+					"invalid batch amount expected %d got %d, batch %s",
+					o.PostageDepth,
+					v.Depth,
+					batchID,
+				)
+			}
+		}
+	}
+	if !found {
+		return fmt.Errorf("cannot find batch %s", batchID)
+	}
+
+	fmt.Printf("node %s: topped up batch id %s\n", node, batchID)
+
+	depthChange := o.PostageNewDepth - o.PostageDepth
+
+	newValue2 := mbig.NewInt(0).Div(newValue, mbig.NewInt(int64(1<<depthChange)))
+
+	err = client.DilutePostageBatch(ctx, batchID, o.PostageNewDepth, o.GasPrice)
+	if err != nil {
+		return fmt.Errorf("failed topping up batch %s with amount %d gas %s: %w", batchID, o.PostageTopupAmount, o.GasPrice, err)
+	}
+	time.Sleep(o.PostageWait)
+
+	batches, err = client.PostageBatches(ctx)
+	if err != nil {
+		return fmt.Errorf("failed getting postage batches %w", err)
+	}
+
+	found = false
+	for _, v := range batches {
+		if v.BatchID == batchID {
+			found = true
+			if v.Amount.Cmp(newValue2) != 0 {
+				return fmt.Errorf(
+					"invalid batch amount expected %d got %d, batch %s",
+					newValue2.Int64(),
+					v.Amount.Int64(),
+					batchID,
+				)
+			}
+			if v.Depth != uint8(o.PostageNewDepth) {
+				return fmt.Errorf(
+					"invalid batch amount expected %d got %d, batch %s",
+					o.PostageNewDepth,
+					v.Depth,
+					batchID,
+				)
+			}
+		}
+	}
+	if !found {
+		return fmt.Errorf("cannot find batch %s", batchID)
+	}
+
+	fmt.Printf("node %s: diluted batch id %s\n", node, batchID)
+
+	return
+}

--- a/pkg/config/check.go
+++ b/pkg/config/check.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/beekeeper/pkg/check/manifest"
 	"github.com/ethersphere/beekeeper/pkg/check/peercount"
 	"github.com/ethersphere/beekeeper/pkg/check/pingpong"
+	"github.com/ethersphere/beekeeper/pkg/check/postage"
 	"github.com/ethersphere/beekeeper/pkg/check/pss"
 	"github.com/ethersphere/beekeeper/pkg/check/pullsync"
 	"github.com/ethersphere/beekeeper/pkg/check/pushsync"
@@ -457,6 +458,27 @@ var Checks = map[string]CheckType{
 				return nil, fmt.Errorf("decoding check %s options: %w", check.Type, err)
 			}
 			opts := contentavailability.NewDefaultOptions()
+			if err := applyCheckConfig(checkGlobalConfig, checkOpts, &opts); err != nil {
+				return nil, fmt.Errorf("applying options: %w", err)
+			}
+			return opts, nil
+		},
+	},
+	"postage": {
+		NewAction: postage.NewCheck,
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+			checkOpts := new(struct {
+				GasPrice           *string `yaml:"gas-price"`
+				PostageAmount      *int64  `yaml:"postage-amount"`
+				PostageTopupAmount *int64  `yaml:"postage-amount"`
+				PostageDepth       *uint64 `yaml:"postage-depth"`
+				PostageNewDepth    *uint64 `yaml:"postage-depth"`
+				PostageLabel       *string `yaml:"postage-label"`
+			})
+			if err := check.Options.Decode(checkOpts); err != nil {
+				return nil, fmt.Errorf("decoding check %s options: %w", check.Type, err)
+			}
+			opts := postage.NewDefaultOptions()
 			if err := applyCheckConfig(checkGlobalConfig, checkOpts, &opts); err != nil {
 				return nil, fmt.Errorf("applying options: %w", err)
 			}

--- a/pkg/config/check.go
+++ b/pkg/config/check.go
@@ -470,9 +470,9 @@ var Checks = map[string]CheckType{
 			checkOpts := new(struct {
 				GasPrice           *string `yaml:"gas-price"`
 				PostageAmount      *int64  `yaml:"postage-amount"`
-				PostageTopupAmount *int64  `yaml:"postage-amount"`
+				PostageTopupAmount *int64  `yaml:"postage-topup-amount"`
 				PostageDepth       *uint64 `yaml:"postage-depth"`
-				PostageNewDepth    *uint64 `yaml:"postage-depth"`
+				PostageNewDepth    *uint64 `yaml:"postage-new-depth"`
 				PostageLabel       *string `yaml:"postage-label"`
 			})
 			if err := check.Options.Decode(checkOpts); err != nil {


### PR DESCRIPTION
- Create batch
- Top Up created batch
- Dilute batch

```shell
❯ beekeeper check --checks=postage --cluster-name=local
field GasPrice not set, using default value
field PostageLabel not set, using default value
node bootnode-0: created new batch id b650913341b03af0ebed9e45adc22e7c08cae988cd49e7950d30ad20e0585eec
node bootnode-0: topped up batch id b650913341b03af0ebed9e45adc22e7c08cae988cd49e7950d30ad20e0585eec
node bootnode-0: diluted batch id b650913341b03af0ebed9e45adc22e7c08cae988cd49e7950d30ad20e0585eec

❯ beekeeper check --checks=ci-postage --cluster-name=local
field GasPrice not set, using default value
field PostageLabel not set, using default value
node bootnode-0: created new batch id 9b1ad03897c0456ed02d846454e35759a493e3772c9e6f7f791a69467f82d2c8
node bootnode-0: topped up batch id 9b1ad03897c0456ed02d846454e35759a493e3772c9e6f7f791a69467f82d2c8
node bootnode-0: diluted batch id 9b1ad03897c0456ed02d846454e35759a493e3772c9e6f7f791a69467f82d2c8
```