### PR TITLE
refactor: replace deprecated ioutil package

### DIFF
--- a/pkg/bee/api/api.go
+++ b/pkg/bee/api/api.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -247,7 +246,7 @@ func drain(r io.ReadCloser) {
 			_ = recover()
 		}()
 
-		_, _ = io.Copy(ioutil.Discard, r)
+		_, _ = io.Copy(io.Discard, r)
 		r.Close()
 	}()
 }

--- a/pkg/bee/client.go
+++ b/pkg/bee/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -142,7 +141,7 @@ func (c *Client) DownloadBytes(ctx context.Context, a swarm.Address) (data []byt
 		return nil, fmt.Errorf("download chunk %s: %w", a, err)
 	}
 
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 // DownloadChunk downloads chunk from the node
@@ -152,7 +151,7 @@ func (c *Client) DownloadChunk(ctx context.Context, a swarm.Address, targets str
 		return nil, fmt.Errorf("download chunk %s: %w", a, err)
 	}
 
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 // DownloadFile downloads chunk from the node and returns it's size and hash

--- a/pkg/bee/debugapi/debugapi.go
+++ b/pkg/bee/debugapi/debugapi.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -189,7 +188,7 @@ func drain(r io.ReadCloser) {
 			_ = recover()
 		}()
 
-		_, _ = io.Copy(ioutil.Discard, r)
+		_, _ = io.Copy(io.Discard, r)
 		r.Close()
 	}()
 }

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"time"
 
@@ -180,7 +180,7 @@ func tarFiles(files []bee.File) (*bytes.Buffer, error) {
 			return nil, err
 		}
 
-		b, err := ioutil.ReadAll(file.DataReader())
+		b, err := io.ReadAll(file.DataReader())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 
@@ -97,7 +97,7 @@ func (c *Config) merge() (err error) {
 // ReadDir reads given directory for YAML files and unmarshals them into Config
 func ReadDir(configDir string) (*Config, error) {
 	// read all files from the directory
-	yamlFiles, err := ioutil.ReadDir(configDir)
+	yamlFiles, err := os.ReadDir(configDir)
 	if err != nil {
 		return nil, fmt.Errorf("reading config dir: %w", err)
 	}
@@ -120,7 +120,7 @@ func ReadDir(configDir string) (*Config, error) {
 		}
 
 		// read file
-		yamlFile, err := ioutil.ReadFile(fullPath)
+		yamlFile, err := os.ReadFile(fullPath)
 		if err != nil {
 			return nil, fmt.Errorf("reading yaml file %s: %w ", file.Name(), err)
 		}

--- a/pkg/swap/http.go
+++ b/pkg/swap/http.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -107,7 +106,7 @@ func drain(r io.ReadCloser) {
 			_ = recover()
 		}()
 
-		_, _ = io.Copy(ioutil.Discard, r)
+		_, _ = io.Copy(io.Discard, r)
 		r.Close()
 	}()
 }


### PR DESCRIPTION
Replace deprecated `ioutil` package functions calls: https://golang.org/doc/go1.16#ioutil