### PR TITLE
add support for attesting existing and clef keys

### DIFF
--- a/pkg/orchestration/k8s/node.go
+++ b/pkg/orchestration/k8s/node.go
@@ -103,6 +103,18 @@ func (n Node) SetSwarmKey(key string) orchestration.Node {
 	return n
 }
 
+// SetClefKey sets node's Clef key
+func (n Node) SetClefKey(key string) orchestration.Node {
+	n.clefKey = key
+	return n
+}
+
+// SetClefKey sets node's Clef key
+func (n Node) SetClefPassword(password string) orchestration.Node {
+	n.clefPassword = password
+	return n
+}
+
 //
 
 func (n Node) Create(ctx context.Context, o orchestration.CreateOptions) (err error) {

--- a/pkg/orchestration/node.go
+++ b/pkg/orchestration/node.go
@@ -26,6 +26,8 @@ type Node interface {
 	Stop(ctx context.Context, namespace string) (err error)
 	SwarmKey() string
 	SetSwarmKey(key string) Node
+	SetClefKey(key string) Node
+	SetClefPassword(key string) Node
 }
 
 // NodeOptions holds optional parameters for the Node.

--- a/pkg/swap/geth.go
+++ b/pkg/swap/geth.go
@@ -182,7 +182,7 @@ func (g *GethClient) SendGBZZ(ctx context.Context, to string, amount float64) (t
 	return resp.Result, nil
 }
 
-func (g *GethClient) AttestOverlayEthAddress(ctx context.Context, ethAddr []byte) (tx string, err error) {
+func (g *GethClient) AttestOverlayEthAddress(ctx context.Context, ethAddr string) (tx string, err error) {
 	ethAccounts, err := g.ethAccounts(ctx)
 	if err != nil {
 		return "", fmt.Errorf("get accounts: %w", err)
@@ -199,7 +199,7 @@ func (g *GethClient) AttestOverlayEthAddress(ctx context.Context, ethAddr []byte
 		Params: []ethRequestParams{{
 			From:     g.ethAccount,
 			To:       g.ethAccount,
-			Data:     fmt.Sprintf("0x%064x", ethAddr),
+			Data:     fmt.Sprintf("0x%064s", ethAddr),
 			Gas:      addPrefix("0x", fmt.Sprintf("%x", BzzGasLimit)),
 			GasPrice: addPrefix("0x", fmt.Sprintf("%x", GasPrice)),
 		}},

--- a/pkg/swap/notset.go
+++ b/pkg/swap/notset.go
@@ -28,6 +28,6 @@ func (n *NotSet) SendGBZZ(ctx context.Context, to string, amount float64) (tx st
 	return "", ErrNotSet
 }
 
-func (n *NotSet) AttestOverlayEthAddress(ctx context.Context, ethAddr []byte) (tx string, err error) {
+func (n *NotSet) AttestOverlayEthAddress(ctx context.Context, ethAddr string) (tx string, err error) {
 	return "", ErrNotSet
 }

--- a/pkg/swap/swap.go
+++ b/pkg/swap/swap.go
@@ -19,5 +19,5 @@ type Client interface {
 	SendETH(ctx context.Context, to string, amount float64) (tx string, err error)
 	SendBZZ(ctx context.Context, to string, amount float64) (tx string, err error)
 	SendGBZZ(ctx context.Context, to string, amount float64) (tx string, err error)
-	AttestOverlayEthAddress(ctx context.Context, ethAddr []byte) (tx string, err error)
+	AttestOverlayEthAddress(ctx context.Context, ethAddr string) (tx string, err error)
 }


### PR DESCRIPTION
* add support for
  * internal signer bee nodes with predefined key without chequebook
  * clef signer bee nodes with predefined key without chequebook
  * clef signer bee nodes without predefined key without chequebook
* key generation has been updated to match the recent bee changes for V3 compatibility