### PR TITLE
feat: enable oidc auth plugin

### DIFF
--- a/cmd/beekeeper/main.go
+++ b/cmd/beekeeper/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/ethersphere/beekeeper/cmd/beekeeper/cmd"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 func main() {


### PR DESCRIPTION
OIDC auth plugin is enabled as described [here](https://github.com/liggitt/kubernetes/blob/master/staging/src/k8s.io/client-go/examples/README.md#auth-plugins)