### PR TITLE
chore: add print command to print all node names inside a cluster

### DIFF
--- a/cmd/beekeeper/cmd/print.go
+++ b/cmd/beekeeper/cmd/print.go
@@ -18,8 +18,8 @@ func (c *command) initPrintCmd() (err error) {
 	cmd := &cobra.Command{
 		Use:   "print",
 		Short: "prints information about a Bee cluster",
-		Long: `Prints information about a Bee cluster: addresses, depths, overlays, peers, topologies
-Requires exactly one argument from the following list: addresses, depths, overlays, peers, topologies`,
+		Long: `Prints information about a Bee cluster: addresses, depths, nodes, overlays, peers, topologies
+Requires exactly one argument from the following list: addresses, depths, nodes, overlays, peers, topologies`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("requires exactly one argument from the following list: addresses, depths, overlays, peers, topologies")
@@ -93,6 +93,15 @@ var (
 				for n, t := range nt {
 					fmt.Printf("Node %s. overlay: %s depth: %d\n", n, t.Overlay, t.Depth)
 				}
+			}
+
+			return
+		},
+		"nodes": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+			nodes := cluster.NodeNames()
+
+			for _, n := range nodes {
+				fmt.Printf("%s\n", n)
 			}
 
 			return


### PR DESCRIPTION
This option is needed for automatic collection of dump data from nodes when the Bee workflow fails.
`beekeeper print nodes --cluster-name local-dns` will print
```
bee-1
bee-0
light-0
light-1
restricted-0
```
and using this info we can easily collect all the data over api and debug api endpoints