### PR TITLE
fix(checks): enable consecutive running checks and log printing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ all: build lint vet test-race binary
 binary: export CGO_ENABLED=0
 binary: dist FORCE
 	$(GO) version
+ifeq ($(OS),Windows_NT)
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/beekeeper.exe ./cmd/beekeeper
+else
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/beekeeper ./cmd/beekeeper
+endif
 
 dist:
 	mkdir $@

--- a/cmd/beekeeper/cmd/check.go
+++ b/cmd/beekeeper/cmd/check.go
@@ -85,10 +85,11 @@ func (c *command) initCheckCmd() (err error) {
 
 			// run checks
 			for _, checkName := range c.globalConfig.GetStringSlice(optionNameChecks) {
+				checkName = strings.TrimSpace(checkName)
 				// get configuration
 				checkConfig, ok := c.config.Checks[checkName]
 				if !ok {
-					return fmt.Errorf("check %s doesn't exist", checkName)
+					return fmt.Errorf("check '%s' doesn't exist", checkName)
 				}
 
 				// choose check type
@@ -115,8 +116,9 @@ func (c *command) initCheckCmd() (err error) {
 					defer cancel()
 				}
 
-				ch := make(chan error, 1)
+				c.logger.Infof("running check: %s", checkName)
 
+				ch := make(chan error, 1)
 				go func() {
 					ch <- chk.Run(ctx, cluster, o)
 					close(ch)
@@ -129,7 +131,7 @@ func (c *command) initCheckCmd() (err error) {
 					if err != nil {
 						return fmt.Errorf("running check %s: %w", checkName, err)
 					}
-					return nil
+					c.logger.Infof("%s check completed successfully", checkName)
 				}
 			}
 			return nil

--- a/pkg/check/authenticated/authenticate.go
+++ b/pkg/check/authenticated/authenticate.go
@@ -46,10 +46,9 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	}
 
 	if o.DryRun {
-		return dryRun(ctx, cluster, o, c.logger)
+		c.logger.Info("running authenticated check (dry run mode)")
+		return dryRun(ctx, cluster, o)
 	}
-
-	c.logger.Info("running authenticated check")
 
 	caseOpts := test.CaseOptions{
 		AdminPassword:       o.AdminPassword,
@@ -75,7 +74,6 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 		return err
 	}
 
-	c.logger.Info("authenticated check completed successfully")
 	return
 }
 
@@ -117,7 +115,6 @@ func testAuth(ctx context.Context, o Options, logger logging.Logger) test.Consum
 }
 
 // dryRun does nothing
-func dryRun(ctx context.Context, cluster orchestration.Cluster, opts interface{}, logger logging.Logger) error {
-	logger.Info("running authenticated check (dry run mode)")
+func dryRun(ctx context.Context, cluster orchestration.Cluster, opts interface{}) error {
 	return nil // success
 }

--- a/pkg/check/balances/balances.go
+++ b/pkg/check/balances/balances.go
@@ -67,8 +67,6 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 		return dryRun(ctx, cluster, o, c.logger)
 	}
 
-	c.logger.Info("running balances")
-
 	var checkCase *test.CheckCase
 
 	caseOpts := test.CaseOptions{

--- a/pkg/check/chunkrepair/chunkrepair.go
+++ b/pkg/check/chunkrepair/chunkrepair.go
@@ -67,7 +67,6 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 }
 
 func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
-	c.logger.Info("running chunk repair")
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/fileretrieval/fileretrieval.go
+++ b/pkg/check/fileretrieval/fileretrieval.go
@@ -77,8 +77,6 @@ var errFileRetrieval = errors.New("file retrieval")
 
 // defaultCheck uploads files on cluster and downloads them from the last node in the cluster
 func (c *Check) defaultCheck(ctx context.Context, cluster orchestration.Cluster, o Options) (err error) {
-	c.logger.Info("running file retrieval")
-
 	rnds := random.PseudoGenerators(o.Seed, o.UploadNodeCount)
 	c.logger.Infof("Seed: %d", o.Seed)
 

--- a/pkg/check/kademlia/kademlia.go
+++ b/pkg/check/kademlia/kademlia.go
@@ -41,7 +41,6 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 }
 
 func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
-	c.logger.Info("running kademlia")
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/pingpong/pingpong.go
+++ b/pkg/check/pingpong/pingpong.go
@@ -40,8 +40,6 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 
 // Run executes ping check
 func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, _ interface{}) (err error) {
-	c.logger.Info("running pingpong")
-
 	nodeGroups := cluster.NodeGroups()
 	for _, ng := range nodeGroups {
 		nodesClients, err := ng.NodesClients(ctx)
@@ -77,8 +75,6 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, _ interf
 			}
 		}
 	}
-
-	c.logger.Info("pingpong check completed successfully")
 	return
 }
 

--- a/pkg/check/pushsync/check_lightnode.go
+++ b/pkg/check/pushsync/check_lightnode.go
@@ -15,6 +15,7 @@ import (
 
 // checkChunks uploads given chunks on cluster and checks pushsync ability of the cluster
 func checkLightChunks(ctx context.Context, cluster orchestration.Cluster, o Options, l logging.Logger) error {
+	l.Info("running pushsync (light-chunks mode)")
 	rnd := random.PseudoGenerator(o.Seed)
 	l.Infof("seed: %d", o.Seed)
 

--- a/pkg/check/pushsync/pushsync.go
+++ b/pkg/check/pushsync/pushsync.go
@@ -80,7 +80,6 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 
 // defaultCheck uploads given chunks on cluster and checks pushsync ability of the cluster
 func (c *Check) defaultCheck(ctx context.Context, cluster orchestration.Cluster, o Options) error {
-	c.logger.Info("running pushsync")
 	rnds := random.PseudoGenerators(o.Seed, o.UploadNodeCount)
 	c.logger.Infof("seed: %d", o.Seed)
 

--- a/pkg/check/settlements/settlements.go
+++ b/pkg/check/settlements/settlements.go
@@ -75,7 +75,6 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 		c.logger.Info("running settlements (dry mode)")
 		return dryRun(ctx, cluster, o, c.logger)
 	}
-	c.logger.Info("running settlements")
 
 	rnd := random.PseudoGenerator(o.Seed)
 	c.logger.Infof("Seed: %d", o.Seed)


### PR DESCRIPTION
Enable (fix) running list of checks (ex: --checks=pingpong,retrieval)
Logger prints every running check: **running check: [checkName]**
Logger prints after every succesfull running check: **[checkName] check completed successfully**
Makefile: when run **make binary**, if OS is Windows  it will add **.exe** to executable file.