### PR TITLE
fix(k8s): test public methods only

### DIFF
--- a/pkg/config/check.go
+++ b/pkg/config/check.go
@@ -511,7 +511,6 @@ func applyCheckConfig(global CheckGlobalConfig, local, opts interface{}) (err er
 			}
 		default:
 			if lv.Field(i).IsNil() {
-				// TODO logger
 				fmt.Printf("field %s not set, using default value\n", fieldName)
 			} else {
 				fieldType := lt.Field(i).Type

--- a/pkg/config/simulation.go
+++ b/pkg/config/simulation.go
@@ -147,7 +147,6 @@ func applySimulationConfig(global SimulationGlobalConfig, local, opts interface{
 			}
 		default:
 			if lv.Field(i).IsNil() {
-				// TODO logger
 				fmt.Printf("field %s not set, using default value\n", fieldName)
 			} else {
 				fieldType := lt.Field(i).Type

--- a/pkg/k8s/configmap/configmap_test.go
+++ b/pkg/k8s/configmap/configmap_test.go
@@ -1,4 +1,4 @@
-package configmap
+package configmap_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/configmap"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,7 +18,7 @@ func TestSet(t *testing.T) {
 	testTable := []struct {
 		name       string
 		configName string
-		options    Options
+		options    configmap.Options
 		clientset  kubernetes.Interface
 		errorMsg   error
 	}{
@@ -25,7 +26,7 @@ func TestSet(t *testing.T) {
 			name:       "create_config_map",
 			configName: "test_config_map",
 			clientset:  fake.NewSimpleClientset(),
-			options: Options{
+			options: configmap.Options{
 				Immutable:   true,
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
@@ -46,7 +47,7 @@ func TestSet(t *testing.T) {
 				BinaryData: map[string][]byte{"bd_1": {1, 2, 3}},
 				Data:       map[string]string{"data_1": "data_value_1"},
 			}),
-			options: Options{
+			options: configmap.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_X", "annotation_2": "annotation_value_2"},
 			},
 		},
@@ -66,7 +67,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := configmap.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.configName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -144,7 +145,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := configmap.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.configName, "test")
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/k8s/containers/containers_test.go
+++ b/pkg/k8s/containers/containers_test.go
@@ -1,9 +1,10 @@
-package containers
+package containers_test
 
 import (
 	"reflect"
 	"testing"
 
+	"github.com/ethersphere/beekeeper/pkg/k8s/containers"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -12,12 +13,12 @@ import (
 func TestToK8S_Containers(t *testing.T) {
 	testTable := []struct {
 		name               string
-		containers         Containers
+		containers         containers.Containers
 		expectedContainers []v1.Container
 	}{
 		{
 			name:       "default",
-			containers: Containers{{}},
+			containers: containers.Containers{{}},
 			expectedContainers: []v1.Container{
 				newExpectedDefaultContainer(),
 			},
@@ -40,12 +41,12 @@ func TestToK8S(t *testing.T) {
 
 	testTable := []struct {
 		name      string
-		container Container
+		container containers.Container
 		expected  v1.Container
 	}{
 		{
 			name: "init_simple",
-			container: Container{
+			container: containers.Container{
 				Name:                     "container",
 				Args:                     []string{"arg1", "arg2"},
 				Command:                  []string{"cmd1", "cmd2"},
@@ -76,27 +77,27 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "env",
-			container: Container{
-				Env: []EnvVar{
+			container: containers.Container{
+				Env: []containers.EnvVar{
 					{
 						Name:  "dev",
 						Value: "default",
-						ValueFrom: ValueFrom{
-							Field: Field{
+						ValueFrom: containers.ValueFrom{
+							Field: containers.Field{
 								APIVersion: "v1",
 								Path:       "/path",
 							},
-							ResourceField: ResourceField{
+							ResourceField: containers.ResourceField{
 								ContainerName: "containerName",
 								Resource:      "resource",
 								Divisor:       "1Gi",
 							},
-							ConfigMap: ConfigMapKey{
+							ConfigMap: containers.ConfigMapKey{
 								ConfigMapName: "configMapName",
 								Key:           "key",
 								Optional:      true,
 							},
-							Secret: SecretKey{
+							Secret: containers.SecretKey{
 								SecretName: "secretName",
 								Key:        "key",
 								Optional:   true,
@@ -143,15 +144,15 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "env_from",
-			container: Container{
-				EnvFrom: []EnvFrom{
+			container: containers.Container{
+				EnvFrom: []containers.EnvFrom{
 					{
 						Prefix: "pre",
-						ConfigMap: ConfigMapRef{
+						ConfigMap: containers.ConfigMapRef{
 							Name:     "configMapName",
 							Optional: true,
 						},
-						Secret: SecretRef{
+						Secret: containers.SecretRef{
 							Name:     "secretName",
 							Optional: true,
 						},
@@ -182,21 +183,21 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "lifecycle_exec",
-			container: Container{
-				Lifecycle: Lifecycle{
-					PostStart: &Handler{
-						Exec: &ExecHandler{
+			container: containers.Container{
+				Lifecycle: containers.Lifecycle{
+					PostStart: &containers.Handler{
+						Exec: &containers.ExecHandler{
 							Command: []string{"cmd_start1", "cmd_start2"},
 						},
-						HTTPGet:   &HTTPGetHandler{},
-						TCPSocket: &TCPSocketHandler{},
+						HTTPGet:   &containers.HTTPGetHandler{},
+						TCPSocket: &containers.TCPSocketHandler{},
 					},
-					PreStop: &Handler{
-						Exec: &ExecHandler{
+					PreStop: &containers.Handler{
+						Exec: &containers.ExecHandler{
 							Command: []string{"cmd_stop1", "cmd_stop2"},
 						},
-						HTTPGet:   &HTTPGetHandler{},
-						TCPSocket: &TCPSocketHandler{},
+						HTTPGet:   &containers.HTTPGetHandler{},
+						TCPSocket: &containers.TCPSocketHandler{},
 					},
 				},
 			},
@@ -219,37 +220,37 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "lifecycle_http",
-			container: Container{
-				Lifecycle: Lifecycle{
-					PostStart: &Handler{
-						HTTPGet: &HTTPGetHandler{
+			container: containers.Container{
+				Lifecycle: containers.Lifecycle{
+					PostStart: &containers.Handler{
+						HTTPGet: &containers.HTTPGetHandler{
 							Host:   "host_start",
 							Path:   "path",
 							Port:   "10000",
 							Scheme: "scheme",
-							HTTPHeaders: []HTTPHeader{
+							HTTPHeaders: []containers.HTTPHeader{
 								{
 									Name:  "headerName",
 									Value: "headerValue",
 								},
 							},
 						},
-						TCPSocket: &TCPSocketHandler{},
+						TCPSocket: &containers.TCPSocketHandler{},
 					},
-					PreStop: &Handler{
-						HTTPGet: &HTTPGetHandler{
+					PreStop: &containers.Handler{
+						HTTPGet: &containers.HTTPGetHandler{
 							Host:   "host_stop",
 							Path:   "path",
 							Port:   "10002",
 							Scheme: "scheme",
-							HTTPHeaders: []HTTPHeader{
+							HTTPHeaders: []containers.HTTPHeader{
 								{
 									Name:  "headerName",
 									Value: "headerValue",
 								},
 							},
 						},
-						TCPSocket: &TCPSocketHandler{},
+						TCPSocket: &containers.TCPSocketHandler{},
 					},
 				},
 			},
@@ -298,16 +299,16 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "lifecycle_tcp",
-			container: Container{
-				Lifecycle: Lifecycle{
-					PostStart: &Handler{
-						TCPSocket: &TCPSocketHandler{
+			container: containers.Container{
+				Lifecycle: containers.Lifecycle{
+					PostStart: &containers.Handler{
+						TCPSocket: &containers.TCPSocketHandler{
 							Host: "tcp_post_start",
 							Port: "10000",
 						},
 					},
-					PreStop: &Handler{
-						TCPSocket: &TCPSocketHandler{
+					PreStop: &containers.Handler{
+						TCPSocket: &containers.TCPSocketHandler{
 							Host: "tcp_pre_stop",
 							Port: "10000",
 						},
@@ -343,10 +344,10 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "lifecycle_no_handlers",
-			container: Container{
-				Lifecycle: Lifecycle{
-					PostStart: &Handler{},
-					PreStop:   &Handler{},
+			container: containers.Container{
+				Lifecycle: containers.Lifecycle{
+					PostStart: &containers.Handler{},
+					PreStop:   &containers.Handler{},
 				},
 			},
 			expected: func() v1.Container {
@@ -360,11 +361,11 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "liveness_probe_exec",
-			container: Container{
-				LivenessProbe: Probe{
-					Exec: &ExecProbe{
+			container: containers.Container{
+				LivenessProbe: containers.Probe{
+					Exec: &containers.ExecProbe{
 						FailureThreshold: 1,
-						Handler: ExecHandler{
+						Handler: containers.ExecHandler{
 							Command: []string{"cmd_probe_1"},
 						},
 						InitialDelaySeconds: 2,
@@ -372,8 +373,8 @@ func TestToK8S(t *testing.T) {
 						SuccessThreshold:    4,
 						TimeoutSeconds:      5,
 					},
-					HTTPGet:   &HTTPGetProbe{},
-					TCPSocket: &TCPSocketProbe{},
+					HTTPGet:   &containers.HTTPGetProbe{},
+					TCPSocket: &containers.TCPSocketProbe{},
 				},
 			},
 			expected: func() v1.Container {
@@ -395,16 +396,16 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "liveness_probe_http",
-			container: Container{
-				LivenessProbe: Probe{
-					HTTPGet: &HTTPGetProbe{
+			container: containers.Container{
+				LivenessProbe: containers.Probe{
+					HTTPGet: &containers.HTTPGetProbe{
 						FailureThreshold: 1,
-						Handler: HTTPGetHandler{
+						Handler: containers.HTTPGetHandler{
 							Host:   "http_host_lp",
 							Path:   "path",
 							Port:   "10000",
 							Scheme: "scheme",
-							HTTPHeaders: []HTTPHeader{
+							HTTPHeaders: []containers.HTTPHeader{
 								{
 									Name:  "headerName",
 									Value: "headerValue",
@@ -416,7 +417,7 @@ func TestToK8S(t *testing.T) {
 						SuccessThreshold:    4,
 						TimeoutSeconds:      5,
 					},
-					TCPSocket: &TCPSocketProbe{},
+					TCPSocket: &containers.TCPSocketProbe{},
 				},
 			},
 			expected: func() v1.Container {
@@ -451,11 +452,11 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "liveness_probe_tcp",
-			container: Container{
-				LivenessProbe: Probe{
-					TCPSocket: &TCPSocketProbe{
+			container: containers.Container{
+				LivenessProbe: containers.Probe{
+					TCPSocket: &containers.TCPSocketProbe{
 						FailureThreshold: 1,
-						Handler: TCPSocketHandler{
+						Handler: containers.TCPSocketHandler{
 							Host: "tcp_lp",
 							Port: "10000",
 						},
@@ -490,8 +491,8 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "ports",
-			container: Container{
-				Ports: []Port{
+			container: containers.Container{
+				Ports: []containers.Port{
 					{
 						Name:          "port",
 						ContainerPort: 12000,
@@ -517,11 +518,11 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "readiness_probe_exec",
-			container: Container{
-				ReadinessProbe: Probe{
-					Exec: &ExecProbe{
+			container: containers.Container{
+				ReadinessProbe: containers.Probe{
+					Exec: &containers.ExecProbe{
 						FailureThreshold: 16,
-						Handler: ExecHandler{
+						Handler: containers.ExecHandler{
 							Command: []string{"cmd_ready_1"},
 						},
 						InitialDelaySeconds: 17,
@@ -529,8 +530,8 @@ func TestToK8S(t *testing.T) {
 						SuccessThreshold:    19,
 						TimeoutSeconds:      20,
 					},
-					HTTPGet:   &HTTPGetProbe{},
-					TCPSocket: &TCPSocketProbe{},
+					HTTPGet:   &containers.HTTPGetProbe{},
+					TCPSocket: &containers.TCPSocketProbe{},
 				},
 			},
 			expected: func() v1.Container {
@@ -552,16 +553,16 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "readiness_probe_http",
-			container: Container{
-				ReadinessProbe: Probe{
-					HTTPGet: &HTTPGetProbe{
+			container: containers.Container{
+				ReadinessProbe: containers.Probe{
+					HTTPGet: &containers.HTTPGetProbe{
 						FailureThreshold: 6,
-						Handler: HTTPGetHandler{
+						Handler: containers.HTTPGetHandler{
 							Host:   "http_host_rp",
 							Path:   "path",
 							Port:   "10000",
 							Scheme: "scheme",
-							HTTPHeaders: []HTTPHeader{
+							HTTPHeaders: []containers.HTTPHeader{
 								{
 									Name:  "headerName",
 									Value: "headerValue",
@@ -573,7 +574,7 @@ func TestToK8S(t *testing.T) {
 						SuccessThreshold:    9,
 						TimeoutSeconds:      10,
 					},
-					TCPSocket: &TCPSocketProbe{},
+					TCPSocket: &containers.TCPSocketProbe{},
 				},
 			},
 			expected: func() v1.Container {
@@ -608,11 +609,11 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "readiness_probe_tcp",
-			container: Container{
-				ReadinessProbe: Probe{
-					TCPSocket: &TCPSocketProbe{
+			container: containers.Container{
+				ReadinessProbe: containers.Probe{
+					TCPSocket: &containers.TCPSocketProbe{
 						FailureThreshold: 1,
-						Handler: TCPSocketHandler{
+						Handler: containers.TCPSocketHandler{
 							Host: "tcp_rp",
 							Port: "10000",
 						},
@@ -647,15 +648,15 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "resources",
-			container: Container{
-				Resources: Resources{
-					Limit: Limit{
+			container: containers.Container{
+				Resources: containers.Resources{
+					Limit: containers.Limit{
 						CPU:              "100",
 						Memory:           "101",
 						Storage:          "102",
 						EphemeralStorage: "103",
 					},
-					Request: Request{
+					Request: containers.Request{
 						CPU:              "200",
 						Memory:           "201",
 						Storage:          "202",
@@ -684,10 +685,10 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "security_context",
-			container: Container{
-				SecurityContext: SecurityContext{
+			container: containers.Container{
+				SecurityContext: containers.SecurityContext{
 					AllowPrivilegeEscalation: true,
-					Capabilities: Capabilities{
+					Capabilities: containers.Capabilities{
 						Add:  []string{"add"},
 						Drop: []string{"drop"},
 					},
@@ -697,13 +698,13 @@ func TestToK8S(t *testing.T) {
 					RunAsGroup:             1,
 					RunAsNonRoot:           true,
 					RunAsUser:              2,
-					SELinuxOptions: SELinuxOptions{
+					SELinuxOptions: containers.SELinuxOptions{
 						User:  "user",
 						Role:  "role",
 						Type:  "type",
 						Level: "level",
 					},
-					WindowsOptions: WindowsOptions{
+					WindowsOptions: containers.WindowsOptions{
 						GMSACredentialSpecName: "name",
 						GMSACredentialSpec:     "spec",
 						RunAsUserName:          "run",
@@ -771,11 +772,11 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "startup_probe_exec",
-			container: Container{
-				StartupProbe: Probe{
-					Exec: &ExecProbe{
+			container: containers.Container{
+				StartupProbe: containers.Probe{
+					Exec: &containers.ExecProbe{
 						FailureThreshold: 31,
-						Handler: ExecHandler{
+						Handler: containers.ExecHandler{
 							Command: []string{"cmd_startup_1"},
 						},
 						InitialDelaySeconds: 32,
@@ -783,8 +784,8 @@ func TestToK8S(t *testing.T) {
 						SuccessThreshold:    34,
 						TimeoutSeconds:      35,
 					},
-					HTTPGet:   &HTTPGetProbe{},
-					TCPSocket: &TCPSocketProbe{},
+					HTTPGet:   &containers.HTTPGetProbe{},
+					TCPSocket: &containers.TCPSocketProbe{},
 				},
 			},
 			expected: func() v1.Container {
@@ -806,16 +807,16 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "startup_probe_http",
-			container: Container{
-				StartupProbe: Probe{
-					HTTPGet: &HTTPGetProbe{
+			container: containers.Container{
+				StartupProbe: containers.Probe{
+					HTTPGet: &containers.HTTPGetProbe{
 						FailureThreshold: 11,
-						Handler: HTTPGetHandler{
+						Handler: containers.HTTPGetHandler{
 							Host:   "http_host_sp",
 							Path:   "path",
 							Port:   "10000",
 							Scheme: "scheme",
-							HTTPHeaders: []HTTPHeader{
+							HTTPHeaders: []containers.HTTPHeader{
 								{
 									Name:  "headerName",
 									Value: "headerValue",
@@ -827,7 +828,7 @@ func TestToK8S(t *testing.T) {
 						SuccessThreshold:    14,
 						TimeoutSeconds:      15,
 					},
-					TCPSocket: &TCPSocketProbe{},
+					TCPSocket: &containers.TCPSocketProbe{},
 				},
 			},
 			expected: func() v1.Container {
@@ -862,11 +863,11 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "startup_probe_tcp",
-			container: Container{
-				StartupProbe: Probe{
-					TCPSocket: &TCPSocketProbe{
+			container: containers.Container{
+				StartupProbe: containers.Probe{
+					TCPSocket: &containers.TCPSocketProbe{
 						FailureThreshold: 1,
-						Handler: TCPSocketHandler{
+						Handler: containers.TCPSocketHandler{
 							Host: "tcp_sp",
 							Port: "10000",
 						},
@@ -901,8 +902,8 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "volume_devices",
-			container: Container{
-				VolumeDevices: []VolumeDevice{
+			container: containers.Container{
+				VolumeDevices: []containers.VolumeDevice{
 					{
 						Name:       "VolumeName",
 						DevicePath: "VolumeDevicePath",
@@ -922,8 +923,8 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "volume_mounts",
-			container: Container{
-				VolumeMounts: []VolumeMount{
+			container: containers.Container{
+				VolumeMounts: []containers.VolumeMount{
 					{
 						Name:      "VolumeMountName",
 						MountPath: "VolumeMountPath",

--- a/pkg/k8s/containers/ephermal_test.go
+++ b/pkg/k8s/containers/ephermal_test.go
@@ -1,21 +1,22 @@
-package containers
+package containers_test
 
 import (
 	"reflect"
 	"testing"
 
+	"github.com/ethersphere/beekeeper/pkg/k8s/containers"
 	v1 "k8s.io/api/core/v1"
 )
 
 func Test_EphemeralContainers_ToK8S(t *testing.T) {
 	testTable := []struct {
 		name               string
-		containers         EphemeralContainers
+		containers         containers.EphemeralContainers
 		expectedContainers []v1.EphemeralContainer
 	}{
 		{
 			name: "default",
-			containers: EphemeralContainers{
+			containers: containers.EphemeralContainers{
 				{
 					TargetContainerName: "test",
 				},

--- a/pkg/k8s/ingress/backend.go
+++ b/pkg/k8s/ingress/backend.go
@@ -16,7 +16,7 @@ func (b *Backend) toK8S() v1.IngressBackend {
 		Service: &v1.IngressServiceBackend{
 			Name: b.ServiceName,
 			Port: v1.ServiceBackendPort{
-				Name: b.ServicePort,
+				Name: b.ServicePort, // TODO check why mapped on name and not on number?
 			},
 		},
 	}

--- a/pkg/k8s/ingress/backend.go
+++ b/pkg/k8s/ingress/backend.go
@@ -6,8 +6,8 @@ import (
 
 // Backend represents Kubernetes IngressBackend
 type Backend struct {
-	ServiceName string
-	ServicePort string
+	ServiceName     string
+	ServicePortName string
 }
 
 // toK8S converts Backend to Kuberntes client object
@@ -16,7 +16,7 @@ func (b *Backend) toK8S() v1.IngressBackend {
 		Service: &v1.IngressServiceBackend{
 			Name: b.ServiceName,
 			Port: v1.ServiceBackendPort{
-				Name: b.ServicePort, // TODO check why mapped on name and not on number?
+				Name: b.ServicePortName,
 			},
 		},
 	}

--- a/pkg/k8s/ingress/client_test.go
+++ b/pkg/k8s/ingress/client_test.go
@@ -1,4 +1,4 @@
-package ingress
+package ingress_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/ingress"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -15,36 +16,80 @@ import (
 
 func TestSet(t *testing.T) {
 	testTable := []struct {
-		name        string
-		ingressName string
-		options     Options
-		clientset   kubernetes.Interface
-		errorMsg    error
+		name         string
+		ingressName  string
+		options      ingress.Options
+		clientset    kubernetes.Interface
+		expectedSpec v1.IngressSpec
+		errorMsg     error
 	}{
 		{
 			name:        "create_ingress",
 			ingressName: "test_ingress",
 			clientset:   fake.NewSimpleClientset(),
-			options: Options{
+			options: ingress.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
-				Spec: Spec{
-					Rules: []Rule{
+				Spec: ingress.Spec{
+					Class: "class",
+					Backend: ingress.Backend{
+						ServiceName: "service_name",
+						ServicePort: "service_port",
+					},
+					Rules: []ingress.Rule{
 						{
 							Host: "host",
-							Paths: []Path{
+							Paths: []ingress.Path{
 								{
-									Backend:  Backend{ServiceName: "sc_name", ServicePort: "9999"},
+									Backend:  ingress.Backend{ServiceName: "sc_name", ServicePort: "9999"},
 									Path:     "/test",
 									PathType: "absolute",
 								},
 							},
 						},
 					},
-					TLS: []TLS{
+					TLS: []ingress.TLS{
 						{
 							Hosts:      []string{"host1", "host2"},
 							SecretName: "secret",
+						},
+					},
+				},
+			},
+			expectedSpec: v1.IngressSpec{
+				IngressClassName: func() *string {
+					class := "class"
+					return &class
+				}(),
+				TLS: []v1.IngressTLS{
+					{
+						Hosts:      []string{"host1", "host2"},
+						SecretName: "secret",
+					},
+				},
+				Rules: []v1.IngressRule{
+					{
+						Host: "host",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Backend: v1.IngressBackend{
+											Service: &v1.IngressServiceBackend{
+												Name: "sc_name",
+												Port: v1.ServiceBackendPort{
+													Name: "9999",
+												},
+											},
+										},
+										Path: "/test",
+										PathType: func() *v1.PathType {
+											pt := v1.PathType("absolute")
+											return &pt
+										}(),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -61,9 +106,10 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: ingress.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_X", "annotation_2": "annotation_value_2"},
 			},
+			expectedSpec: v1.IngressSpec{},
 		},
 		{
 			name:        "create_error",
@@ -81,7 +127,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := ingress.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.ingressName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -98,11 +144,10 @@ func TestSet(t *testing.T) {
 						Annotations: test.options.Annotations,
 						Labels:      test.options.Labels,
 					},
-					Spec: test.options.Spec.toK8S(),
+					Spec: test.expectedSpec,
 				}
-
-				if !reflect.DeepEqual(response, expected) {
-					t.Errorf("response expected: %q, got: %q", response, expected)
+				if !reflect.DeepEqual(*response, *expected) {
+					t.Errorf("response expected: %#v, got: %#v", expected, response)
 				}
 
 			} else {
@@ -157,7 +202,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := ingress.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.ingressName, "test")
 			if test.errorMsg == nil {
 				if err != nil {
@@ -174,3 +219,25 @@ func TestDelete(t *testing.T) {
 		})
 	}
 }
+
+// func TestToK8s(t *testing.T) {
+// 	testTable := []struct {
+// 		name     string
+// 		options  ingress.Options
+// 		errorMsg error
+// 	}{
+// 		{
+// 			name:     "test",
+// 			options:  ingress.Options{},
+// 			errorMsg: nil,
+// 		},
+// 	}
+
+// 	for _, test := range testTable {
+// 		t.Run(test.name, func(t *testing.T) {
+// 			ingresSpec := test.options.Spec.ToK8S()
+// 			if len(ingresSpec.Rules) == 0 {
+// 			}
+// 		})
+// 	}
+// }

--- a/pkg/k8s/ingress/client_test.go
+++ b/pkg/k8s/ingress/client_test.go
@@ -32,11 +32,7 @@ func TestSet(t *testing.T) {
 				Labels:      map[string]string{"label_1": "label_value_1"},
 				Spec: ingress.Spec{
 					Class: "class",
-<<<<<<< HEAD
 					Backend: ingress.Backend{
-=======
-					Backend: ingress.Backend{ // TODO check the role of this Backend?
->>>>>>> b4fa6307dbb77ede76aa4cd74c9402481398037d
 						ServiceName: "service_name",
 						ServicePort: "service_port",
 					},

--- a/pkg/k8s/ingress/client_test.go
+++ b/pkg/k8s/ingress/client_test.go
@@ -32,16 +32,12 @@ func TestSet(t *testing.T) {
 				Labels:      map[string]string{"label_1": "label_value_1"},
 				Spec: ingress.Spec{
 					Class: "class",
-					Backend: ingress.Backend{
-						ServiceName: "service_name",
-						ServicePort: "service_port",
-					},
 					Rules: []ingress.Rule{
 						{
 							Host: "host",
 							Paths: []ingress.Path{
 								{
-									Backend:  ingress.Backend{ServiceName: "sc_name", ServicePort: "9999"},
+									Backend:  ingress.Backend{ServiceName: "sc_name", ServicePortName: "9999"},
 									Path:     "/test",
 									PathType: "absolute",
 								},

--- a/pkg/k8s/ingress/ingress.go
+++ b/pkg/k8s/ingress/ingress.go
@@ -4,10 +4,9 @@ import v1 "k8s.io/api/networking/v1"
 
 // Spec represents Kubernetes IngressSpec
 type Spec struct {
-	Class   string
-	Backend Backend // TODO check the role of this here, seems not needed
-	TLS     TLSs
-	Rules   Rules
+	Class string
+	TLS   TLSs
+	Rules Rules
 }
 
 // toK8S converts IngressSpec to Kuberntes client object

--- a/pkg/k8s/ingress/ingress.go
+++ b/pkg/k8s/ingress/ingress.go
@@ -5,7 +5,7 @@ import v1 "k8s.io/api/networking/v1"
 // Spec represents Kubernetes IngressSpec
 type Spec struct {
 	Class   string
-	Backend Backend
+	Backend Backend // TODO check the role of this here, seems not needed
 	TLS     TLSs
 	Rules   Rules
 }
@@ -13,8 +13,13 @@ type Spec struct {
 // toK8S converts IngressSpec to Kuberntes client object
 func (s *Spec) toK8S() v1.IngressSpec {
 	return v1.IngressSpec{
-		IngressClassName: &s.Class,
-		Rules:            s.Rules.toK8S(),
-		TLS:              s.TLS.toK8S(),
+		IngressClassName: func(class string) *string {
+			if class != "" {
+				return &class
+			}
+			return nil
+		}(s.Class),
+		Rules: s.Rules.toK8S(),
+		TLS:   s.TLS.toK8S(),
 	}
 }

--- a/pkg/k8s/ingress/rule.go
+++ b/pkg/k8s/ingress/rule.go
@@ -7,12 +7,13 @@ type Rules []Rule
 
 // toK8S converts Rules to Kuberntes client objects
 func (rs Rules) toK8S() (l []v1.IngressRule) {
-	l = make([]v1.IngressRule, 0, len(rs))
+	if len(rs) > 0 {
+		l = make([]v1.IngressRule, 0, len(rs))
 
-	for _, r := range rs {
-		l = append(l, r.toK8S())
+		for _, r := range rs {
+			l = append(l, r.toK8S())
+		}
 	}
-
 	return
 }
 
@@ -39,12 +40,13 @@ type Paths []Path
 
 // toK8S converts Paths to Kuberntes client objects
 func (ps Paths) toK8S() (l []v1.HTTPIngressPath) {
-	l = make([]v1.HTTPIngressPath, 0, len(ps))
+	if len(ps) > 0 {
+		l = make([]v1.HTTPIngressPath, 0, len(ps))
 
-	for _, p := range ps {
-		l = append(l, p.toK8S())
+		for _, p := range ps {
+			l = append(l, p.toK8S())
+		}
 	}
-
 	return
 }
 

--- a/pkg/k8s/ingress/tls.go
+++ b/pkg/k8s/ingress/tls.go
@@ -7,12 +7,13 @@ type TLSs []TLS
 
 // toK8S converts TLSs to Kuberntes client objects
 func (ts TLSs) toK8S() (l []v1.IngressTLS) {
-	l = make([]v1.IngressTLS, 0, len(ts))
+	if len(ts) > 0 {
+		l = make([]v1.IngressTLS, 0, len(ts))
 
-	for _, t := range ts {
-		l = append(l, t.toK8S())
+		for _, t := range ts {
+			l = append(l, t.toK8S())
+		}
 	}
-
 	return
 }
 
@@ -25,10 +26,7 @@ type TLS struct {
 // toK8S converts TLS to Kuberntes client object
 func (t *TLS) toK8S() (tls v1.IngressTLS) {
 	return v1.IngressTLS{
-		Hosts: func() (hosts []string) {
-			hosts = append(hosts, t.Hosts...)
-			return
-		}(),
+		Hosts:      t.Hosts,
 		SecretName: t.SecretName,
 	}
 }

--- a/pkg/k8s/ingress/tls.go
+++ b/pkg/k8s/ingress/tls.go
@@ -26,16 +26,7 @@ type TLS struct {
 // toK8S converts TLS to Kuberntes client object
 func (t *TLS) toK8S() (tls v1.IngressTLS) {
 	return v1.IngressTLS{
-<<<<<<< HEAD
 		Hosts:      t.Hosts,
-=======
-		Hosts: func() (hosts []string) {
-			if len(t.Hosts) > 0 {
-				hosts = append(hosts, t.Hosts...)
-			}
-			return
-		}(),
->>>>>>> b4fa6307dbb77ede76aa4cd74c9402481398037d
 		SecretName: t.SecretName,
 	}
 }

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -1,4 +1,4 @@
-package k8s
+package k8s_test
 
 import (
 	"fmt"
@@ -6,38 +6,39 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s"
 	"github.com/ethersphere/beekeeper/pkg/logging"
 )
 
 func TestNewClient(t *testing.T) {
 	testTable := []struct {
 		name     string
-		options  *ClientOptions
-		k8sFuncs *ClientSetup
+		options  *k8s.ClientOptions
+		k8sFuncs *k8s.ClientSetup
 		errorMsg error
 	}{
 		{
 			name:     "in_cluster_config_error",
-			options:  &ClientOptions{InCluster: true},
+			options:  &k8s.ClientOptions{InCluster: true},
 			errorMsg: fmt.Errorf("creating Kubernetes in-cluster client config: mock error"),
-			k8sFuncs: &ClientSetup{
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:    mock.NewClient(false).NewForConfig,
 				InClusterConfig: mock.NewClient(true).InClusterConfig,
 			},
 		},
 		{
 			name:     "in_cluster_clientset_error",
-			options:  &ClientOptions{InCluster: true},
+			options:  &k8s.ClientOptions{InCluster: true},
 			errorMsg: fmt.Errorf("creating Kubernetes in-cluster clientset: mock error"),
-			k8sFuncs: &ClientSetup{
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:    mock.NewClient(true).NewForConfig,
 				InClusterConfig: mock.NewClient(false).InClusterConfig,
 			},
 		},
 		{
 			name:    "in_cluster",
-			options: &ClientOptions{InCluster: true},
-			k8sFuncs: &ClientSetup{
+			options: &k8s.ClientOptions{InCluster: true},
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:    mock.NewClient(false).NewForConfig,
 				InClusterConfig: mock.NewClient(false).InClusterConfig,
 			},
@@ -45,7 +46,7 @@ func TestNewClient(t *testing.T) {
 		{
 			name:    "not_in_cluster_default_path",
 			options: nil,
-			k8sFuncs: &ClientSetup{
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:         mock.NewClient(false).NewForConfig,
 				InClusterConfig:      mock.NewClient(false).InClusterConfig,
 				OsUserHomeDir:        mock.NewClient(false).OsUserHomeDir,
@@ -57,7 +58,7 @@ func TestNewClient(t *testing.T) {
 		{
 			name:    "not_in_cluster_default_path_fail_clientset",
 			options: nil,
-			k8sFuncs: &ClientSetup{
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:         mock.NewClient(true).NewForConfig,
 				InClusterConfig:      mock.NewClient(false).InClusterConfig,
 				OsUserHomeDir:        mock.NewClient(false).OsUserHomeDir,
@@ -70,7 +71,7 @@ func TestNewClient(t *testing.T) {
 		{
 			name:    "not_in_cluster_default_path_bad",
 			options: nil,
-			k8sFuncs: &ClientSetup{
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:         mock.NewClient(false).NewForConfig,
 				InClusterConfig:      mock.NewClient(false).InClusterConfig,
 				OsUserHomeDir:        mock.NewClient(false).OsUserHomeDir,
@@ -82,8 +83,8 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:    "not_in_cluster_other_path",
-			options: &ClientOptions{InCluster: false, KubeconfigPath: "~/.kube/test_example"},
-			k8sFuncs: &ClientSetup{
+			options: &k8s.ClientOptions{InCluster: false, KubeconfigPath: "~/.kube/test_example"},
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:         mock.NewClient(false).NewForConfig,
 				InClusterConfig:      mock.NewClient(false).InClusterConfig,
 				BuildConfigFromFlags: mock.NewClient(false).BuildConfigFromFlags,
@@ -93,8 +94,8 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:    "not_in_cluster_fail_home_dir",
-			options: &ClientOptions{InCluster: false, KubeconfigPath: "~/.kube/config"},
-			k8sFuncs: &ClientSetup{
+			options: &k8s.ClientOptions{InCluster: false, KubeconfigPath: "~/.kube/config"},
+			k8sFuncs: &k8s.ClientSetup{
 				NewForConfig:    mock.NewClient(false).NewForConfig,
 				InClusterConfig: mock.NewClient(false).InClusterConfig,
 				OsUserHomeDir:   mock.NewClient(true).OsUserHomeDir,
@@ -103,14 +104,14 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:     "not_in_cluster_empty_path",
-			options:  &ClientOptions{},
-			errorMsg: ErrKubeconfigNotSet,
+			options:  &k8s.ClientOptions{},
+			errorMsg: k8s.ErrKubeconfigNotSet,
 		},
 	}
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			response, err := NewClient(test.k8sFuncs, test.options, logging.New(io.Discard, 0, ""))
+			response, err := k8s.NewClient(test.k8sFuncs, test.options, logging.New(io.Discard, 0, ""))
 			if test.errorMsg == nil {
 				if err != nil {
 					t.Errorf("error not expected, got: %s", err.Error())

--- a/pkg/k8s/namespace/namespace_test.go
+++ b/pkg/k8s/namespace/namespace_test.go
@@ -1,4 +1,4 @@
-package namespace
+package namespace_test
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethersphere/beekeeper"
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/namespace"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -30,7 +31,7 @@ func TestCreate(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := namespace.NewClient(test.clientset)
 			response, err := client.Create(context.Background(), test.nsName)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -75,7 +76,7 @@ func TestUpdate(t *testing.T) {
 		name      string
 		nsName    string
 		clientset kubernetes.Interface
-		otpions   Options
+		otpions   namespace.Options
 		errorMsg  error
 	}{
 		{
@@ -92,7 +93,7 @@ func TestUpdate(t *testing.T) {
 					},
 				},
 			}),
-			otpions: Options{
+			otpions: namespace.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
 			},
@@ -101,7 +102,7 @@ func TestUpdate(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := namespace.NewClient(test.clientset)
 			response, err := client.Update(context.Background(), test.nsName, test.otpions)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -207,7 +208,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := namespace.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.nsName)
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/k8s/persistentvolumeclaim/accessmode.go
+++ b/pkg/k8s/persistentvolumeclaim/accessmode.go
@@ -7,12 +7,12 @@ type AccessModes []AccessMode
 
 // toK8S converts AccessModes to Kuberntes client objects
 func (ams AccessModes) toK8S() (l []v1.PersistentVolumeAccessMode) {
-	l = make([]v1.PersistentVolumeAccessMode, 0, len(ams))
-
-	for _, am := range ams {
-		l = append(l, am.toK8S())
+	if len(ams) > 0 {
+		l = make([]v1.PersistentVolumeAccessMode, 0, len(ams))
+		for _, am := range ams {
+			l = append(l, am.toK8S())
+		}
 	}
-
 	return
 }
 

--- a/pkg/k8s/persistentvolumeclaim/client_test.go
+++ b/pkg/k8s/persistentvolumeclaim/client_test.go
@@ -1,4 +1,4 @@
-package persistentvolumeclaim
+package persistentvolumeclaim_test
 
 import (
 	"context"
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	pvc "github.com/ethersphere/beekeeper/pkg/k8s/persistentvolumeclaim"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -15,53 +17,34 @@ import (
 
 func TestSet(t *testing.T) {
 	testTable := []struct {
-		name      string
-		pvcName   string
-		options   Options
-		clientset kubernetes.Interface
-		errorMsg  error
+		name         string
+		pvcName      string
+		options      pvc.Options
+		clientset    kubernetes.Interface
+		expectedSpec v1.PersistentVolumeClaimSpec
+		errorMsg     error
 	}{
 		{
-			name:      "create_pvc",
+			name:      "create_pvc_default_spec",
 			pvcName:   "test_pvc",
 			clientset: fake.NewSimpleClientset(),
-			options: Options{
+			options: pvc.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
-				Spec: PersistentVolumeClaimSpec{
-					AccessModes:    []AccessMode{"1", "2"},
-					RequestStorage: "1Gi",
-					Selector: Selector{
-						MatchLabels: map[string]string{"label_1": "label_value_1"},
-						MatchExpressions: []LabelSelectorRequirement{
-							{
-								Key:      "label_1",
-								Operator: "==",
-								Values:   []string{"label_value_1"},
-							},
-						},
-					},
-					VolumeName: "volume_1",
-				},
 			},
-		},
-		{
-			name:      "create_pvc_spec_volume_mode_Block",
-			pvcName:   "test_pvc",
-			clientset: fake.NewSimpleClientset(),
-			options: Options{
-				Spec: PersistentVolumeClaimSpec{
-					VolumeMode: "Block",
+			expectedSpec: v1.PersistentVolumeClaimSpec{
+				Selector: &metav1.LabelSelector{},
+				Resources: v1.ResourceRequirements{
+					Limits:   nil,
+					Requests: map[v1.ResourceName]resource.Quantity{},
 				},
-			},
-		},
-		{
-			name:      "create_pvc_spec_volume_mode_block",
-			pvcName:   "test_pvc",
-			clientset: fake.NewSimpleClientset(),
-			options: Options{
-				Spec: PersistentVolumeClaimSpec{
-					VolumeMode: "block",
+				VolumeMode: func() *v1.PersistentVolumeMode {
+					m := v1.PersistentVolumeFilesystem
+					return &m
+				}(),
+				StorageClassName: getAddress(""),
+				DataSource: &v1.TypedLocalObjectReference{
+					APIGroup: getAddress(""),
 				},
 			},
 		},
@@ -76,8 +59,23 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: pvc.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_X", "annotation_2": "annotation_value_2"},
+			},
+			expectedSpec: v1.PersistentVolumeClaimSpec{
+				Selector: &metav1.LabelSelector{},
+				Resources: v1.ResourceRequirements{
+					Limits:   nil,
+					Requests: map[v1.ResourceName]resource.Quantity{},
+				},
+				VolumeMode: func() *v1.PersistentVolumeMode {
+					m := v1.PersistentVolumeFilesystem
+					return &m
+				}(),
+				StorageClassName: getAddress(""),
+				DataSource: &v1.TypedLocalObjectReference{
+					APIGroup: getAddress(""),
+				},
 			},
 		},
 		{
@@ -96,7 +94,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := pvc.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.pvcName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -106,16 +104,6 @@ func TestSet(t *testing.T) {
 					t.Fatalf("response is expected")
 				}
 
-				expectedSpec := test.options.Spec.toK8S()
-
-				if test.options.Spec.VolumeMode == "Block" || test.options.Spec.VolumeMode == "block" {
-					m := v1.PersistentVolumeBlock
-					expectedSpec.VolumeMode = &m
-				} else {
-					m := v1.PersistentVolumeFilesystem
-					expectedSpec.VolumeMode = &m
-				}
-
 				expected := &v1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        test.pvcName,
@@ -123,7 +111,7 @@ func TestSet(t *testing.T) {
 						Annotations: test.options.Annotations,
 						Labels:      test.options.Labels,
 					},
-					Spec: expectedSpec,
+					Spec: test.expectedSpec,
 				}
 
 				if !reflect.DeepEqual(response, expected) {
@@ -182,7 +170,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := pvc.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.pvcName, "test")
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/k8s/persistentvolumeclaim/client_test.go
+++ b/pkg/k8s/persistentvolumeclaim/client_test.go
@@ -9,7 +9,6 @@ import (
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
 	pvc "github.com/ethersphere/beekeeper/pkg/k8s/persistentvolumeclaim"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -34,10 +33,6 @@ func TestSet(t *testing.T) {
 			},
 			expectedSpec: v1.PersistentVolumeClaimSpec{
 				Selector: &metav1.LabelSelector{},
-				Resources: v1.ResourceRequirements{
-					Limits:   nil,
-					Requests: map[v1.ResourceName]resource.Quantity{},
-				},
 				VolumeMode: func() *v1.PersistentVolumeMode {
 					m := v1.PersistentVolumeFilesystem
 					return &m
@@ -64,10 +59,6 @@ func TestSet(t *testing.T) {
 			},
 			expectedSpec: v1.PersistentVolumeClaimSpec{
 				Selector: &metav1.LabelSelector{},
-				Resources: v1.ResourceRequirements{
-					Limits:   nil,
-					Requests: map[v1.ResourceName]resource.Quantity{},
-				},
 				VolumeMode: func() *v1.PersistentVolumeMode {
 					m := v1.PersistentVolumeFilesystem
 					return &m

--- a/pkg/k8s/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/pkg/k8s/persistentvolumeclaim/persistentvolumeclaim.go
@@ -1,6 +1,8 @@
 package persistentvolumeclaim
 
 import (
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,12 +13,12 @@ type PersistentVolumeClaims []PersistentVolumeClaim
 
 // ToK8S converts PersistentVolumeClaims to Kuberntes client objects
 func (ps PersistentVolumeClaims) ToK8S() (l []v1.PersistentVolumeClaim) {
-	l = make([]v1.PersistentVolumeClaim, 0, len(ps))
-
-	for _, p := range ps {
-		l = append(l, p.ToK8S())
+	if len(ps) > 0 {
+		l = make([]v1.PersistentVolumeClaim, 0, len(ps))
+		for _, p := range ps {
+			l = append(l, p.toK8S())
+		}
 	}
-
 	return
 }
 
@@ -29,8 +31,8 @@ type PersistentVolumeClaim struct {
 	Spec        PersistentVolumeClaimSpec
 }
 
-// ToK8S converts PersistentVolumeClaim to Kuberntes client object
-func (pvc PersistentVolumeClaim) ToK8S() v1.PersistentVolumeClaim {
+// toK8S converts PersistentVolumeClaim to Kuberntes client object
+func (pvc PersistentVolumeClaim) toK8S() v1.PersistentVolumeClaim {
 	return v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvc.Name,
@@ -72,7 +74,7 @@ func (pvcs PersistentVolumeClaimSpec) toK8S() v1.PersistentVolumeClaimSpec {
 		StorageClassName: &pvcs.StorageClass,
 		VolumeName:       pvcs.VolumeName,
 		VolumeMode: func() *v1.PersistentVolumeMode {
-			if pvcs.VolumeMode == "Block" || pvcs.VolumeMode == "block" {
+			if strings.ToLower(pvcs.VolumeMode) == "block" {
 				m := v1.PersistentVolumeBlock
 				return &m
 			}

--- a/pkg/k8s/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/pkg/k8s/persistentvolumeclaim/persistentvolumeclaim.go
@@ -62,9 +62,9 @@ func (pvcs PersistentVolumeClaimSpec) toK8S() v1.PersistentVolumeClaimSpec {
 		AccessModes: pvcs.AccessModes.toK8S(),
 		DataSource:  pvcs.DataSource.toK8S(),
 		Resources: v1.ResourceRequirements{
-			Requests: func() v1.ResourceList {
-				m := map[v1.ResourceName]resource.Quantity{}
+			Requests: func() (m v1.ResourceList) {
 				if len(pvcs.RequestStorage) > 0 {
+					m = make(map[v1.ResourceName]resource.Quantity)
 					m[v1.ResourceStorage] = resource.MustParse(pvcs.RequestStorage)
 				}
 				return m
@@ -74,7 +74,7 @@ func (pvcs PersistentVolumeClaimSpec) toK8S() v1.PersistentVolumeClaimSpec {
 		StorageClassName: &pvcs.StorageClass,
 		VolumeName:       pvcs.VolumeName,
 		VolumeMode: func() *v1.PersistentVolumeMode {
-			if strings.ToLower(pvcs.VolumeMode) == "block" {
+			if strings.EqualFold(pvcs.VolumeMode, "block") {
 				m := v1.PersistentVolumeBlock
 				return &m
 			}

--- a/pkg/k8s/persistentvolumeclaim/persistentvolumeclaim_test.go
+++ b/pkg/k8s/persistentvolumeclaim/persistentvolumeclaim_test.go
@@ -95,7 +95,7 @@ func TestToK8s(t *testing.T) {
 			pvcs: pvc.PersistentVolumeClaims{
 				{
 					Spec: pvc.PersistentVolumeClaimSpec{
-						VolumeMode: "block",
+						VolumeMode: "Block",
 					},
 				},
 			},
@@ -103,10 +103,6 @@ func TestToK8s(t *testing.T) {
 				{
 					Spec: v1.PersistentVolumeClaimSpec{
 						Selector: &metav1.LabelSelector{},
-						Resources: v1.ResourceRequirements{
-							Limits:   nil,
-							Requests: map[v1.ResourceName]resource.Quantity{},
-						},
 						VolumeMode: func() *v1.PersistentVolumeMode {
 							m := v1.PersistentVolumeBlock
 							return &m

--- a/pkg/k8s/persistentvolumeclaim/selector.go
+++ b/pkg/k8s/persistentvolumeclaim/selector.go
@@ -23,12 +23,12 @@ type LabelSelectorRequirements []LabelSelectorRequirement
 
 // toK8S converts LabelSelectorRequirements to Kuberntes client object
 func (lsrs LabelSelectorRequirements) toK8S() (l []metav1.LabelSelectorRequirement) {
-	l = make([]metav1.LabelSelectorRequirement, 0, len(lsrs))
-
-	for _, lsr := range lsrs {
-		l = append(l, lsr.toK8S())
+	if len(lsrs) > 0 {
+		l = make([]metav1.LabelSelectorRequirement, 0, len(lsrs))
+		for _, lsr := range lsrs {
+			l = append(l, lsr.toK8S())
+		}
 	}
-
 	return
 }
 

--- a/pkg/k8s/pod/client_test.go
+++ b/pkg/k8s/pod/client_test.go
@@ -1,4 +1,4 @@
-package pod
+package pod_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/pod"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,7 +18,7 @@ func TestSet(t *testing.T) {
 	testTable := []struct {
 		name      string
 		podName   string
-		options   Options
+		options   pod.Options
 		clientset kubernetes.Interface
 		errorMsg  error
 	}{
@@ -25,7 +26,7 @@ func TestSet(t *testing.T) {
 			name:      "create_pod",
 			podName:   "test_pod",
 			clientset: fake.NewSimpleClientset(),
-			options: Options{
+			options: pod.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
 			},
@@ -41,7 +42,7 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: pod.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_X", "annotation_2": "annotation_value_2"},
 			},
 		},
@@ -61,7 +62,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := pod.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.podName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -78,7 +79,7 @@ func TestSet(t *testing.T) {
 						Annotations: test.options.Annotations,
 						Labels:      test.options.Labels,
 					},
-					Spec: test.options.PodSpec.toK8S(),
+					Spec: newDefaultPodTemplateSpec().Spec,
 				}
 
 				if !reflect.DeepEqual(response, expected) {
@@ -137,7 +138,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := pod.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.podName, "test")
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/k8s/pod/pod_test.go
+++ b/pkg/k8s/pod/pod_test.go
@@ -1,9 +1,10 @@
-package pod
+package pod_test
 
 import (
 	"reflect"
 	"testing"
 
+	"github.com/ethersphere/beekeeper/pkg/k8s/pod"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,36 +13,36 @@ import (
 func TestToK8S(t *testing.T) {
 	testTable := []struct {
 		name     string
-		pts      PodTemplateSpec
+		pts      pod.PodTemplateSpec
 		expected v1.PodTemplateSpec
 	}{
 		{
 			name:     "default",
-			pts:      PodTemplateSpec{},
-			expected: newDefaultPodSpec(),
+			pts:      pod.PodTemplateSpec{},
+			expected: newDefaultPodTemplateSpec(),
 		},
 		{
 			name: "image_pull_secrets",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
 					ImagePullSecrets: []string{"test_1", "test_2"},
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.ImagePullSecrets = []v1.LocalObjectReference{{Name: "test_1"}, {Name: "test_2"}}
 				return newPodSpec
 			}(),
 		},
 		{
 			name: "preemption_policy",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
 					PreemptionPolicy: "test",
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.PreemptionPolicy = func() *v1.PreemptionPolicy {
 					pp := v1.PreemptionPolicy("test")
 					return &pp
@@ -51,21 +52,21 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "node_affinity",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Affinity: Affinity{
-						NodeAffinity: &NodeAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: PreferredSchedulingTerms{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Affinity: pod.Affinity{
+						NodeAffinity: &pod.NodeAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: pod.PreferredSchedulingTerms{
 								{
-									Preference: NodeSelectorTerm{
-										MatchExpressions: NodeSelectorRequirements{
+									Preference: pod.NodeSelectorTerm{
+										MatchExpressions: pod.NodeSelectorRequirements{
 											{
 												Key:      "key_1",
 												Operator: "operator_1",
 												Values:   []string{"value_1"},
 											},
 										},
-										MatchFields: NodeSelectorRequirements{
+										MatchFields: pod.NodeSelectorRequirements{
 											{
 												Key:      "key_2",
 												Operator: "operator_2",
@@ -76,17 +77,17 @@ func TestToK8S(t *testing.T) {
 									Weight: 1,
 								},
 							},
-							RequiredDuringSchedulingIgnoredDuringExecution: NodeSelector{
-								NodeSelectorTerms: NodeSelectorTerms{
+							RequiredDuringSchedulingIgnoredDuringExecution: pod.NodeSelector{
+								NodeSelectorTerms: pod.NodeSelectorTerms{
 									{
-										MatchExpressions: NodeSelectorRequirements{
+										MatchExpressions: pod.NodeSelectorRequirements{
 											{
 												Key:      "key_3",
 												Operator: "operator_3",
 												Values:   []string{"value_3"},
 											},
 										},
-										MatchFields: NodeSelectorRequirements{
+										MatchFields: pod.NodeSelectorRequirements{
 											{
 												Key:      "key_4",
 												Operator: "operator_4",
@@ -101,7 +102,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Affinity = &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
 						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
@@ -142,13 +143,13 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "pod_affinity",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Affinity: Affinity{
-						PodAffinity: &PodAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: WeightedPodAffinityTerms{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Affinity: pod.Affinity{
+						PodAffinity: &pod.PodAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: pod.WeightedPodAffinityTerms{
 								{
-									PodAffinityTerm: PodAffinityTerm{
+									PodAffinityTerm: pod.PodAffinityTerm{
 										LabelSelector: map[string]string{"label_1": "label_value_1"},
 										Namespaces:    []string{"namespaces_1"},
 										TopologyKey:   "topology_key_1",
@@ -156,7 +157,7 @@ func TestToK8S(t *testing.T) {
 									Weight: 1,
 								},
 							},
-							RequiredDuringSchedulingIgnoredDuringExecution: PodAffinityTerms{
+							RequiredDuringSchedulingIgnoredDuringExecution: pod.PodAffinityTerms{
 								{
 									LabelSelector: map[string]string{"label_2": "label_value_2"},
 									Namespaces:    []string{"namespaces_2"},
@@ -168,7 +169,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Affinity = &v1.Affinity{
 					PodAffinity: &v1.PodAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
@@ -195,20 +196,20 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "pod_anti_affinity",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Affinity: Affinity{
-						PodAntiAffinity: &PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: PodAffinityTerms{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Affinity: pod.Affinity{
+						PodAntiAffinity: &pod.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: pod.PodAffinityTerms{
 								{
 									LabelSelector: map[string]string{"label_3": "label_value_3"},
 									Namespaces:    []string{"namespaces_3"},
 									TopologyKey:   "topology_key_3",
 								},
 							},
-							PreferredDuringSchedulingIgnoredDuringExecution: WeightedPodAffinityTerms{
+							PreferredDuringSchedulingIgnoredDuringExecution: pod.WeightedPodAffinityTerms{
 								{
-									PodAffinityTerm: PodAffinityTerm{
+									PodAffinityTerm: pod.PodAffinityTerm{
 										LabelSelector: map[string]string{"label_4": "label_value_4"},
 										Namespaces:    []string{"namespaces_4"},
 										TopologyKey:   "topology_key_4",
@@ -221,7 +222,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Affinity = &v1.Affinity{
 					PodAntiAffinity: &v1.PodAntiAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
@@ -248,12 +249,12 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "dns_config",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					DNSConfig: PodDNSConfig{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					DNSConfig: pod.PodDNSConfig{
 						Nameservers: []string{"server_1"},
 						Searches:    []string{"search_1"},
-						Options: []PodDNSConfigOption{
+						Options: []pod.PodDNSConfigOption{
 							{
 								Name:  "option_1",
 								Value: "value_1",
@@ -263,7 +264,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.DNSConfig = &v1.PodDNSConfig{
 					Nameservers: []string{"server_1"},
 					Searches:    []string{"search_1"},
@@ -282,9 +283,9 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "host_aliases",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					HostAliases: HostAliases{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					HostAliases: pod.HostAliases{
 						{
 							IP:        "8.8.8.8",
 							Hostnames: []string{"host"},
@@ -293,7 +294,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.HostAliases = []v1.HostAlias{{
 					IP:        "8.8.8.8",
 					Hostnames: []string{"host"},
@@ -303,15 +304,15 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "pod_readiness_gate",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					ReadinessGates: PodReadinessGates{{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					ReadinessGates: pod.PodReadinessGates{{
 						ConditionType: "condition",
 					}},
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.ReadinessGates = []v1.PodReadinessGate{{
 					ConditionType: "condition",
 				}}
@@ -320,9 +321,9 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "tolerations",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Tolerations: Tolerations{{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Tolerations: pod.Tolerations{{
 						Key:               "key",
 						Operator:          "operator",
 						Value:             "value",
@@ -332,7 +333,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Tolerations = []v1.Toleration{{
 					Key:      "key",
 					Operator: "operator",
@@ -348,9 +349,9 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "topology_spread_constraints",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					TopologySpreadConstraints: TopologySpreadConstraints{{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					TopologySpreadConstraints: pod.TopologySpreadConstraints{{
 						MaxSkew:           1,
 						TopologyKey:       "topology_key",
 						WhenUnsatisfiable: "when_unsatisfiable",
@@ -359,7 +360,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
 					MaxSkew:           1,
 					TopologyKey:       "topology_key",
@@ -374,10 +375,10 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "volumes_empty_dir",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Volumes: Volumes{{
-						EmptyDir: &EmptyDirVolume{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Volumes: pod.Volumes{{
+						EmptyDir: &pod.EmptyDirVolume{
 							Name:      "name",
 							Medium:    "Memory",
 							SizeLimit: "1",
@@ -386,7 +387,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Volumes = []v1.Volume{{
 					Name: "name",
 					VolumeSource: v1.VolumeSource{
@@ -404,10 +405,10 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "volumes_empty_dir_no_size_limit",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Volumes: Volumes{{
-						EmptyDir: &EmptyDirVolume{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Volumes: pod.Volumes{{
+						EmptyDir: &pod.EmptyDirVolume{
 							Name:   "name",
 							Medium: "Memory",
 						},
@@ -415,7 +416,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Volumes = []v1.Volume{{
 					Name: "name",
 					VolumeSource: v1.VolumeSource{
@@ -430,14 +431,14 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "volumes_config_map",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Volumes: Volumes{{
-						ConfigMap: &ConfigMapVolume{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Volumes: pod.Volumes{{
+						ConfigMap: &pod.ConfigMapVolume{
 							Name:          "name",
 							ConfigMapName: "cm_name",
 							DefaultMode:   1,
-							Items: []Item{{
+							Items: []pod.Item{{
 								Key:   "key",
 								Value: "value",
 							}},
@@ -447,7 +448,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Volumes = []v1.Volume{{
 					Name: "name",
 					VolumeSource: v1.VolumeSource{
@@ -474,14 +475,14 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "volumes_secret",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Volumes: Volumes{{
-						Secret: &SecretVolume{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Volumes: pod.Volumes{{
+						Secret: &pod.SecretVolume{
 							Name:        "name",
 							SecretName:  "secret_name",
 							DefaultMode: 1,
-							Items: []Item{{
+							Items: []pod.Item{{
 								Key:   "key",
 								Value: "value",
 							}},
@@ -491,7 +492,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Volumes = []v1.Volume{{
 					Name: "name",
 					VolumeSource: v1.VolumeSource{
@@ -518,23 +519,23 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "volumes_not_defined",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					Volumes: Volumes{{}},
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					Volumes: pod.Volumes{{}},
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.Volumes = []v1.Volume{{}}
 				return newPodSpec
 			}(),
 		},
 		{
 			name: "security_sysctl",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					PodSecurityContext: PodSecurityContext{
-						Sysctls: Sysctls{{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					PodSecurityContext: pod.PodSecurityContext{
+						Sysctls: pod.Sysctls{{
 							Name:  "name",
 							Value: "value",
 						}},
@@ -542,7 +543,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.SecurityContext.Sysctls = []v1.Sysctl{{
 					Name:  "name",
 					Value: "value",
@@ -552,10 +553,10 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "security_windows_options",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					PodSecurityContext: PodSecurityContext{
-						WindowsOptions: WindowsOptions{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					PodSecurityContext: pod.PodSecurityContext{
+						WindowsOptions: pod.WindowsOptions{
 							GMSACredentialSpecName: "spec_name",
 							GMSACredentialSpec:     "spec",
 							RunAsUserName:          "user",
@@ -564,7 +565,7 @@ func TestToK8S(t *testing.T) {
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.SecurityContext.WindowsOptions = &v1.WindowsSecurityContextOptions{
 					GMSACredentialSpecName: func() *string {
 						name := "spec_name"
@@ -584,15 +585,15 @@ func TestToK8S(t *testing.T) {
 		},
 		{
 			name: "security_fs_group_change_policy",
-			pts: PodTemplateSpec{
-				Spec: PodSpec{
-					PodSecurityContext: PodSecurityContext{
+			pts: pod.PodTemplateSpec{
+				Spec: pod.PodSpec{
+					PodSecurityContext: pod.PodSecurityContext{
 						FSGroupChangePolicy: "test",
 					},
 				},
 			},
 			expected: func() v1.PodTemplateSpec {
-				newPodSpec := newDefaultPodSpec()
+				newPodSpec := newDefaultPodTemplateSpec()
 				newPodSpec.Spec.SecurityContext.FSGroupChangePolicy = func() *v1.PodFSGroupChangePolicy {
 					f := v1.PodFSGroupChangePolicy("test")
 					return &f
@@ -613,7 +614,7 @@ func TestToK8S(t *testing.T) {
 	}
 }
 
-func newDefaultPodSpec() v1.PodTemplateSpec {
+func newDefaultPodTemplateSpec() v1.PodTemplateSpec {
 	return v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: v1.PodSpec{

--- a/pkg/k8s/secret/secret_test.go
+++ b/pkg/k8s/secret/secret_test.go
@@ -1,4 +1,4 @@
-package secret
+package secret_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/secret"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,7 +18,7 @@ func TestSet(t *testing.T) {
 	testTable := []struct {
 		name       string
 		secretName string
-		options    Options
+		options    secret.Options
 		clientset  kubernetes.Interface
 		errorMsg   error
 	}{
@@ -25,7 +26,7 @@ func TestSet(t *testing.T) {
 			name:       "create_secret",
 			secretName: "test_secret",
 			clientset:  fake.NewSimpleClientset(),
-			options: Options{
+			options: secret.Options{
 				Immutable:   true,
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
@@ -46,7 +47,7 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: secret.Options{
 				Immutable:   true,
 				Annotations: map[string]string{"annotation_1": "annotation_value_updated"},
 				Labels:      map[string]string{"label_1": "label_value_updated"},
@@ -71,7 +72,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := secret.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.secretName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -150,7 +151,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := secret.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.secretName, "test")
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/k8s/service/client_test.go
+++ b/pkg/k8s/service/client_test.go
@@ -1,4 +1,4 @@
-package service
+package service_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/service"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,7 +18,7 @@ func TestSet(t *testing.T) {
 	testTable := []struct {
 		name        string
 		serviceName string
-		options     Options
+		options     service.Options
 		clientset   kubernetes.Interface
 		errorMsg    error
 	}{
@@ -25,7 +26,7 @@ func TestSet(t *testing.T) {
 			name:        "create_service",
 			serviceName: "test_service",
 			clientset:   fake.NewSimpleClientset(),
-			options: Options{
+			options: service.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
 			},
@@ -41,7 +42,7 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: service.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_X", "annotation_2": "annotation_value_2"},
 			},
 		},
@@ -49,9 +50,9 @@ func TestSet(t *testing.T) {
 			name:        "spec_ports",
 			serviceName: "test_service",
 			clientset:   fake.NewSimpleClientset(),
-			options: Options{
-				ServiceSpec: Spec{
-					Ports: []Port{
+			options: service.Options{
+				ServiceSpec: service.Spec{
+					Ports: []service.Port{
 						{
 							Name: "http8080", Port: 8080, AppProtocol: "http", Nodeport: 80, Protocol: "http", TargetPort: "80",
 						},
@@ -84,7 +85,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := service.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.serviceName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -160,7 +161,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := service.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.serviceName, "test")
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/k8s/serviceaccount/serviceaccount_test.go
+++ b/pkg/k8s/serviceaccount/serviceaccount_test.go
@@ -1,4 +1,4 @@
-package serviceaccount
+package serviceaccount_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/serviceaccount"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,7 +18,7 @@ func TestSet(t *testing.T) {
 	testTable := []struct {
 		name       string
 		secretName string
-		options    Options
+		options    serviceaccount.Options
 		clientset  kubernetes.Interface
 		errorMsg   error
 	}{
@@ -25,7 +26,7 @@ func TestSet(t *testing.T) {
 			name:       "create_service_account",
 			secretName: "test_service_account",
 			clientset:  fake.NewSimpleClientset(),
-			options: Options{
+			options: serviceaccount.Options{
 				Annotations:                  map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:                       map[string]string{"label_1": "label_value_1"},
 				AutomountServiceAccountToken: true,
@@ -44,7 +45,7 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: serviceaccount.Options{
 				Annotations:                  map[string]string{"annotation_1": "annotation_value_updated"},
 				Labels:                       map[string]string{"label_1": "label_value_updated"},
 				AutomountServiceAccountToken: true,
@@ -68,7 +69,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := serviceaccount.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.secretName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -156,7 +157,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := serviceaccount.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.secretName, "test")
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/k8s/statefulset/client_test.go
+++ b/pkg/k8s/statefulset/client_test.go
@@ -1,4 +1,4 @@
-package statefulset
+package statefulset_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mock "github.com/ethersphere/beekeeper/mocks/k8s"
+	"github.com/ethersphere/beekeeper/pkg/k8s/statefulset"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,7 @@ func TestSet(t *testing.T) {
 	testTable := []struct {
 		name            string
 		statefulsetName string
-		options         Options
+		options         statefulset.Options
 		clientset       kubernetes.Interface
 		errorMsg        error
 	}{
@@ -26,7 +27,7 @@ func TestSet(t *testing.T) {
 			name:            "create_statefulset",
 			statefulsetName: "test_statefulset",
 			clientset:       fake.NewSimpleClientset(),
-			options: Options{
+			options: statefulset.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_1"},
 				Labels:      map[string]string{"label_1": "label_value_1"},
 			},
@@ -42,7 +43,7 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: statefulset.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_X", "annotation_2": "annotation_value_2"},
 			},
 		},
@@ -57,9 +58,9 @@ func TestSet(t *testing.T) {
 					Labels:      map[string]string{"label_1": "label_value_1"},
 				},
 			}),
-			options: Options{
+			options: statefulset.Options{
 				Annotations: map[string]string{"annotation_1": "annotation_value_X", "annotation_2": "annotation_value_2"},
-				Spec:        StatefulSetSpec{UpdateStrategy: UpdateStrategy{Type: "OnDelete"}},
+				Spec:        statefulset.StatefulSetSpec{UpdateStrategy: statefulset.UpdateStrategy{Type: "OnDelete"}},
 			},
 		},
 		{
@@ -78,7 +79,7 @@ func TestSet(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := statefulset.NewClient(test.clientset)
 			response, err := client.Set(context.Background(), test.statefulsetName, "test", test.options)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -166,7 +167,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := statefulset.NewClient(test.clientset)
 			err := client.Delete(context.Background(), test.statefulsetName, "test")
 			if test.errorMsg == nil {
 				if err != nil {
@@ -220,7 +221,7 @@ func TestReadyReplicas(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := statefulset.NewClient(test.clientset)
 			ready, err := client.ReadyReplicas(context.Background(), test.statefulsetName, "test")
 			if test.errorMsg == nil {
 				if err != nil {
@@ -293,7 +294,7 @@ func TestRunningStatefulSets(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := statefulset.NewClient(test.clientset)
 			response, err := client.RunningStatefulSets(context.Background(), test.namespace)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -368,7 +369,7 @@ func TestScale(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := statefulset.NewClient(test.clientset)
 			response, err := client.Scale(context.Background(), test.statefulSetName, test.namespace, 3)
 			if test.errorMsg == nil {
 				if err != nil {
@@ -455,7 +456,7 @@ func TestStoppedStatefulSets(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			client := NewClient(test.clientset)
+			client := statefulset.NewClient(test.clientset)
 			response, err := client.StoppedStatefulSets(context.Background(), test.namespace)
 			if test.errorMsg == nil {
 				if err != nil {

--- a/pkg/orchestration/k8s/node.go
+++ b/pkg/orchestration/k8s/node.go
@@ -227,8 +227,8 @@ func (n Node) Create(ctx context.Context, o orchestration.CreateOptions) (err er
 				Host: o.IngressHost,
 				Paths: ingress.Paths{{
 					Backend: ingress.Backend{
-						ServiceName: apiSvc,
-						ServicePort: "api",
+						ServiceName:     apiSvc,
+						ServicePortName: "api",
 					},
 					Path:     "/",
 					PathType: "ImplementationSpecific",
@@ -278,8 +278,8 @@ func (n Node) Create(ctx context.Context, o orchestration.CreateOptions) (err er
 				Host: o.IngressDebugHost,
 				Paths: ingress.Paths{{
 					Backend: ingress.Backend{
-						ServiceName: debugSvc,
-						ServicePort: "debug",
+						ServiceName:     debugSvc,
+						ServicePortName: "debug",
 					},
 					Path:     "/",
 					PathType: "ImplementationSpecific",


### PR DESCRIPTION
All unit tests are moved to dedicated test packages, and code is modified accordingly. 
Quality of test cases is improved. 
Minor improvements are included in k8s packages  (init slice only when needed).