### PR TITLE
fix(k8s): add missing update option for ingress route

### DIFF
--- a/pkg/k8s/customresource/ingressroute/client.go
+++ b/pkg/k8s/customresource/ingressroute/client.go
@@ -45,7 +45,7 @@ func (c *Client) Set(ctx context.Context, name, namespace string, o Options) (in
 		},
 	}
 
-	ing, err = c.clientset.IngressRoutes(namespace).Update(ctx, spec)
+	ing, err = c.clientset.IngressRoutes(namespace).Update(ctx, spec, metav1.UpdateOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			ing, err = c.clientset.IngressRoutes(namespace).Create(ctx, spec)

--- a/pkg/k8s/customresource/ingressroute/client.go
+++ b/pkg/k8s/customresource/ingressroute/client.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Client manages communication with the Kubernetes Ingress.
+// Client manages communication with the Traefik IngressRoute.
 type Client struct {
 	clientset Interface
 }
@@ -27,7 +27,7 @@ type Options struct {
 	Spec        IngressRouteSpec
 }
 
-// Set updates Ingress or creates it if it does not exist
+// Set updates IngressRoute or creates it if it does not exist
 func (c *Client) Set(ctx context.Context, name, namespace string, o Options) (ing *IngressRoute, err error) {
 	spec := &IngressRoute{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/k8s/customresource/ingressroute/client.go
+++ b/pkg/k8s/customresource/ingressroute/client.go
@@ -44,7 +44,18 @@ func (c *Client) Set(ctx context.Context, name, namespace string, o Options) (in
 			Routes: o.Spec.Routes,
 		},
 	}
-	ing, err = c.clientset.IngressRoutes(namespace).Create(ctx, spec)
+
+	ing, err = c.clientset.IngressRoutes(namespace).Update(ctx, spec)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			ing, err = c.clientset.IngressRoutes(namespace).Create(ctx, spec)
+			if err != nil {
+				return nil, fmt.Errorf("creating ingress route %s in namespace %s: %w", name, namespace, err)
+			}
+		} else {
+			return nil, fmt.Errorf("updating ingress route %s in namespace %s: %w", name, namespace, err)
+		}
+	}
 	return
 }
 

--- a/pkg/k8s/customresource/ingressroute/ingressroute.go
+++ b/pkg/k8s/customresource/ingressroute/ingressroute.go
@@ -14,7 +14,7 @@ type IngressRouteInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*IngressRouteList, error)
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*IngressRoute, error)
 	Create(ctx context.Context, ir *IngressRoute) (*IngressRoute, error)
-	Update(ctx context.Context, ir *IngressRoute) (*IngressRoute, error)
+	Update(ctx context.Context, ir *IngressRoute, opts metav1.UpdateOptions) (*IngressRoute, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 }
@@ -71,13 +71,14 @@ func (c *ingressRouteClient) Create(ctx context.Context, ingressRoute *IngressRo
 }
 
 // Update takes the representation of a ingressRoute and updates it. Returns the server's representation of the ingressRoute, and an error, if there is any.
-func (c *ingressRouteClient) Update(ctx context.Context, ir *IngressRoute) (*IngressRoute, error) {
+func (c *ingressRouteClient) Update(ctx context.Context, ir *IngressRoute, opts metav1.UpdateOptions) (*IngressRoute, error) {
 	result := IngressRoute{}
 	err := c.restClient.
 		Put().
 		Namespace(c.ns).
 		Resource(IngressRouteResource).
 		Name(ir.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(ir).
 		Do(ctx).
 		Into(&result)

--- a/pkg/k8s/customresource/ingressroute/ingressroute.go
+++ b/pkg/k8s/customresource/ingressroute/ingressroute.go
@@ -14,6 +14,7 @@ type IngressRouteInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*IngressRouteList, error)
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*IngressRoute, error)
 	Create(ctx context.Context, ir *IngressRoute) (*IngressRoute, error)
+	Update(ctx context.Context, ir *IngressRoute) (*IngressRoute, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 }
@@ -66,6 +67,20 @@ func (c *ingressRouteClient) Create(ctx context.Context, ingressRoute *IngressRo
 		Do(ctx).
 		Into(&result)
 
+	return &result, err
+}
+
+// Update takes the representation of a ingressRoute and updates it. Returns the server's representation of the ingressRoute, and an error, if there is any.
+func (c *ingressRouteClient) Update(ctx context.Context, ir *IngressRoute) (*IngressRoute, error) {
+	result := IngressRoute{}
+	err := c.restClient.
+		Put().
+		Namespace(c.ns).
+		Resource(IngressRouteResource).
+		Name(ir.Name).
+		Body(ir).
+		Do(ctx).
+		Into(&result)
 	return &result, err
 }
 


### PR DESCRIPTION
IngressRoute client Set method updates IngressRoute or creates it if it does not exist