### PR TITLE
feat: print config

### DIFF
--- a/cmd/beekeeper/cmd/cmd.go
+++ b/cmd/beekeeper/cmd/cmd.go
@@ -220,7 +220,7 @@ func (c *command) initConfig() (err error) {
 		if err != nil {
 			return err
 		}
-		yamlFiles := [][]byte{}
+		yamlFiles := []config.YamlFile{}
 		for _, file := range files {
 			if file.IsDir() || (!strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml")) {
 				continue
@@ -235,10 +235,13 @@ func (c *command) initConfig() (err error) {
 			if _, err := f.Read(yamlFile); err != nil {
 				return fmt.Errorf("reading file %s: %w ", file.Name(), err)
 			}
-			yamlFiles = append(yamlFiles, yamlFile)
+			yamlFiles = append(yamlFiles, config.YamlFile{
+				Name:    file.Name(),
+				Content: yamlFile,
+			})
 		}
 
-		if c.config, err = config.Read(yamlFiles...); err != nil {
+		if c.config, err = config.Read(c.logger, yamlFiles); err != nil {
 			return err
 		}
 	} else {
@@ -248,7 +251,7 @@ func (c *command) initConfig() (err error) {
 			return fmt.Errorf("reading config dir: %w", err)
 		}
 
-		yamlFiles := [][]byte{}
+		yamlFiles := []config.YamlFile{}
 		for _, file := range files {
 			fullPath := filepath.Join(c.globalConfig.GetString(optionNameConfigDir) + "/" + file.Name())
 			fileExt := filepath.Ext(fullPath)
@@ -259,10 +262,13 @@ func (c *command) initConfig() (err error) {
 			if err != nil {
 				return fmt.Errorf("reading file %s: %w ", file.Name(), err)
 			}
-			yamlFiles = append(yamlFiles, yamlFile)
+			yamlFiles = append(yamlFiles, config.YamlFile{
+				Name:    file.Name(),
+				Content: yamlFile,
+			})
 		}
 
-		if c.config, err = config.Read(yamlFiles...); err != nil {
+		if c.config, err = config.Read(c.logger, yamlFiles); err != nil {
 			return err
 		}
 	}

--- a/cmd/beekeeper/cmd/print.go
+++ b/cmd/beekeeper/cmd/print.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/ethersphere/beekeeper/pkg/orchestration"
@@ -22,18 +23,24 @@ func (c *command) initPrintCmd() (err error) {
 Requires exactly one argument from the following list: addresses, depths, nodes, overlays, peers, topologies`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("requires exactly one argument from the following list: addresses, depths, nodes, overlays, peers, topologies")
+				return fmt.Errorf("requires exactly one argument from the following list: addresses, depths, nodes, overlays, peers, topologies, config")
 			}
 
-			for k := range printFuncs {
-				if k == args[0] {
-					return nil
-				}
+			if _, ok := printFuncs[args[0]]; !ok {
+				return fmt.Errorf("argument '%s' is not from the following list: addresses, depths, nodes, overlays, peers, topologies, config", args[0])
 			}
 
-			return fmt.Errorf("requires exactly one argument from the following list: addresses, depths, nodes, overlays, peers, topologies")
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			// no need to setup cluster in case of config print
+			if args[0] == "config" {
+				if err := c.config.PrintYaml(os.Stdout); err != nil {
+					return fmt.Errorf("config can not be printed: %s", err.Error())
+				}
+				return
+			}
+
 			ctx, cancel := context.WithTimeout(cmd.Context(), c.globalConfig.GetDuration(optionNameTimeout))
 			defer cancel()
 
@@ -49,7 +56,13 @@ Requires exactly one argument from the following list: addresses, depths, nodes,
 
 			return f(ctx, cluster)
 		},
-		PreRunE: c.preRunE,
+		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			// skip setup in case of config print
+			if args[0] == "config" {
+				return
+			}
+			return c.preRunE(cmd, args)
+		},
 	}
 
 	cmd.PersistentFlags().String(optionNameClusterName, "default", "cluster name")
@@ -60,104 +73,107 @@ Requires exactly one argument from the following list: addresses, depths, nodes,
 	return nil
 }
 
-var (
-	printFuncs = map[string]func(ctx context.Context, cluster orchestration.Cluster) (err error){
-		"addresses": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
-			addresses, err := cluster.Addresses(ctx)
-			if err != nil {
-				return err
-			}
+var printFuncs = map[string]func(ctx context.Context, cluster orchestration.Cluster) (err error){
+	"addresses": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+		addresses, err := cluster.Addresses(ctx)
+		if err != nil {
+			return err
+		}
 
-			for ng, na := range addresses {
-				fmt.Printf("Printing %s node group's addresses\n", ng)
-				for n, a := range na {
-					fmt.Printf("Node %s. ethereum: %s\n", n, a.Ethereum)
-					fmt.Printf("Node %s. public key: %s\n", n, a.PublicKey)
-					fmt.Printf("Node %s. overlay: %s\n", n, a.Overlay)
-					for _, u := range a.Underlay {
-						fmt.Printf("Node %s. underlay: %s\n", n, u)
-					}
+		for ng, na := range addresses {
+			fmt.Printf("Printing %s node group's addresses\n", ng)
+			for n, a := range na {
+				fmt.Printf("Node %s. ethereum: %s\n", n, a.Ethereum)
+				fmt.Printf("Node %s. public key: %s\n", n, a.PublicKey)
+				fmt.Printf("Node %s. overlay: %s\n", n, a.Overlay)
+				for _, u := range a.Underlay {
+					fmt.Printf("Node %s. underlay: %s\n", n, u)
 				}
 			}
+		}
 
-			return
-		},
-		"depths": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
-			topologies, err := cluster.Topologies(ctx)
-			if err != nil {
-				return err
+		return
+	},
+	"depths": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+		topologies, err := cluster.Topologies(ctx)
+		if err != nil {
+			return err
+		}
+
+		for ng, nt := range topologies {
+			fmt.Printf("Printing %s node group's topologies\n", ng)
+			for n, t := range nt {
+				fmt.Printf("Node %s. overlay: %s depth: %d\n", n, t.Overlay, t.Depth)
 			}
+		}
 
-			for ng, nt := range topologies {
-				fmt.Printf("Printing %s node group's topologies\n", ng)
-				for n, t := range nt {
-					fmt.Printf("Node %s. overlay: %s depth: %d\n", n, t.Overlay, t.Depth)
+		return
+	},
+	"nodes": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+		nodes := cluster.NodeNames()
+
+		for _, n := range nodes {
+			fmt.Printf("%s\n", n)
+		}
+
+		return
+	},
+	"overlays": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+		overlays, err := cluster.Overlays(ctx)
+		if err != nil {
+			return err
+		}
+
+		for ng, no := range overlays {
+			fmt.Printf("Printing %s node group's overlays\n", ng)
+			for n, o := range no {
+				fmt.Printf("Node %s. %s\n", n, o.String())
+			}
+		}
+
+		return
+	},
+	"peers": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+		peers, err := cluster.Peers(ctx)
+		if err != nil {
+			return err
+		}
+
+		for ng, np := range peers {
+			fmt.Printf("Printing %s node group's peers\n", ng)
+			for n, a := range np {
+				for _, p := range a {
+					fmt.Printf("Node %s. %s\n", n, p)
 				}
 			}
+		}
+		return
+	},
+	"topologies": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+		topologies, err := cluster.Topologies(ctx)
+		if err != nil {
+			return err
+		}
 
-			return
-		},
-		"nodes": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
-			nodes := cluster.NodeNames()
-
-			for _, n := range nodes {
-				fmt.Printf("%s\n", n)
-			}
-
-			return
-		},
-		"overlays": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
-			overlays, err := cluster.Overlays(ctx)
-			if err != nil {
-				return err
-			}
-
-			for ng, no := range overlays {
-				fmt.Printf("Printing %s node group's overlays\n", ng)
-				for n, o := range no {
-					fmt.Printf("Node %s. %s\n", n, o.String())
+		for ng, nt := range topologies {
+			fmt.Printf("Printing %s node group's topologies\n", ng)
+			for n, t := range nt {
+				fmt.Printf("Node %s. overlay: %s\n", n, t.Overlay)
+				fmt.Printf("Node %s. population: %d\n", n, t.Population)
+				fmt.Printf("Node %s. connected: %d\n", n, t.Connected)
+				fmt.Printf("Node %s. depth: %d\n", n, t.Depth)
+				fmt.Printf("Node %s. nnLowWatermark: %d\n", n, t.NnLowWatermark)
+				for k, v := range t.Bins {
+					fmt.Printf("Node %s. %s %+v\n", n, k, v)
 				}
 			}
+		}
 
-			return
-		},
-		"peers": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
-			peers, err := cluster.Peers(ctx)
-			if err != nil {
-				return err
-			}
-
-			for ng, np := range peers {
-				fmt.Printf("Printing %s node group's peers\n", ng)
-				for n, a := range np {
-					for _, p := range a {
-						fmt.Printf("Node %s. %s\n", n, p)
-					}
-				}
-			}
-			return
-		},
-		"topologies": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
-			topologies, err := cluster.Topologies(ctx)
-			if err != nil {
-				return err
-			}
-
-			for ng, nt := range topologies {
-				fmt.Printf("Printing %s node group's topologies\n", ng)
-				for n, t := range nt {
-					fmt.Printf("Node %s. overlay: %s\n", n, t.Overlay)
-					fmt.Printf("Node %s. population: %d\n", n, t.Population)
-					fmt.Printf("Node %s. connected: %d\n", n, t.Connected)
-					fmt.Printf("Node %s. depth: %d\n", n, t.Depth)
-					fmt.Printf("Node %s. nnLowWatermark: %d\n", n, t.NnLowWatermark)
-					for k, v := range t.Bins {
-						fmt.Printf("Node %s. %s %+v\n", n, k, v)
-					}
-				}
-			}
-
-			return
-		},
-	}
-)
+		return
+	},
+	// add it to print funcs and do nothing (required to check if argument exists)
+	// print config prints configuration used to setup cluster
+	"config": func(ctx context.Context, cluster orchestration.Cluster) (err error) {
+		return
+	},
+}


### PR DESCRIPTION
- add 'print config' option that dumps used configuration for cluster setup
- add log warnings when configuration is duplicated (in which case duplicated configuration is not taken into account)