### PR TITLE
fix: detect timeout with select in statefullset watch request

### DIFF
--- a/mocks/k8s/statefulset.go
+++ b/mocks/k8s/statefulset.go
@@ -121,6 +121,7 @@ func (*StatefulSet) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	case opts.FieldSelector == "metadata.name=test_statefulset":
 		watcher := watch.NewFake()
 		go func() {
+			defer watcher.Stop()
 			watcher.Add(&v1.StatefulSet{
 				Status: v1.StatefulSetStatus{
 					Replicas:      1,
@@ -129,17 +130,12 @@ func (*StatefulSet) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 			})
 		}()
 		return watcher, nil
-	case opts.FieldSelector == "metadata.name=test_statefulset_not_ready":
+	case opts.FieldSelector == "metadata.name=test_statefulset_watcher_stop":
 		watcher := watch.NewFake()
-		go func() {
-			defer watcher.Stop()
-			watcher.Add(&v1.StatefulSet{
-				Status: v1.StatefulSetStatus{
-					Replicas:      0,
-					ReadyReplicas: 1,
-				},
-			})
-		}()
+		watcher.Stop()
+		return watcher, nil
+	case opts.FieldSelector == "metadata.name=test_statefulset_context_cancel":
+		watcher := watch.NewFake()
 		return watcher, nil
 	default:
 		return nil, fmt.Errorf("mock error: unknown")

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -146,7 +146,7 @@ func newClient(clientset *kubernetes.Clientset, apiClientset *ingressroute.Custo
 	c.Secret = secret.NewClient(clientset)
 	c.ServiceAccount = serviceaccount.NewClient(clientset)
 	c.Service = service.NewClient(clientset)
-	c.StatefulSet = statefulset.NewClient(clientset)
+	c.StatefulSet = statefulset.NewClient(clientset, logger)
 	c.IngressRoute = ingressroute.NewClient(apiClientset)
 
 	return c

--- a/pkg/orchestration/k8s/node.go
+++ b/pkg/orchestration/k8s/node.go
@@ -502,7 +502,6 @@ func (n Node) Create(ctx context.Context, o orchestration.CreateOptions) (err er
 	}
 	n.logger.Infof("statefulset %s is set in namespace %s", sSet, o.Namespace)
 
-	n.logger.Infof("node %s started in namespace %s", o.Name, o.Namespace)
 	return
 }
 

--- a/pkg/orchestration/k8s/nodegroup.go
+++ b/pkg/orchestration/k8s/nodegroup.go
@@ -919,6 +919,7 @@ func (g *NodeGroup) StartNode(ctx context.Context, name string) (err error) {
 	}
 
 	g.logger.Infof("wait for %s to become ready", name)
+
 	for {
 		ok, err := g.NodeReady(ctx, name)
 		if err != nil {
@@ -929,9 +930,6 @@ func (g *NodeGroup) StartNode(ctx context.Context, name string) (err error) {
 			g.logger.Infof("%s is ready", name)
 			return nil
 		}
-
-		g.logger.Infof("%s is not ready yet", name)
-		time.Sleep(nodeRetryTimeout)
 	}
 }
 
@@ -947,6 +945,7 @@ func (g *NodeGroup) StopNode(ctx context.Context, name string) (err error) {
 	}
 
 	g.logger.Infof("wait for %s to stop", name)
+
 	for {
 		ok, err := g.NodeReady(ctx, name)
 		if err != nil {
@@ -957,9 +956,6 @@ func (g *NodeGroup) StopNode(ctx context.Context, name string) (err error) {
 			g.logger.Infof("%s is stopped", name)
 			return nil
 		}
-
-		g.logger.Infof("%s is not stopped yet", name)
-		time.Sleep(nodeRetryTimeout)
 	}
 }
 

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package beekeeper
 
 var (
-	version = "0.12.0" // manually set semantic version number
+	version = "0.12.2" // manually set semantic version number
 	commit  string     // automatically set git commit hash
 
 	// Version TODO


### PR DESCRIPTION
This pull request addresses an issue encountered when attempting to make a request to the k8s watch API to verify whether the statefulset contained sufficient ready replicas. Previously, when the context deadline was exceeded, the request would not return an error and would be retried indefinitely. The changes made in this pull request resolve the root cause of this issue.




