### PR TITLE
fix: toolchain not available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethersphere/beekeeper
 
-go 1.22
+go 1.22.0
 
 replace github.com/codahale/hdrhistogram => github.com/HdrHistogram/hdrhistogram-go v1.1.2
 


### PR DESCRIPTION
`make binary`
`go: download go1.22 for darwin/arm64: toolchain not available`

see: [this comment](https://github.com/golang/go/issues/62278#issuecomment-1933790368)