### PR TITLE
refactor: extract label-selector as a flag for node-funder and operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ It has following flags:
 --min-native float        Minimum amount of chain native coins (xDAI) nodes should have.
 --min-swarm float         Minimum amount of swarm tokens (xBZZ) nodes should have.
 --namespace string        Kubernetes namespace. Overrides cluster name if set.
+--label-selector string   Kubernetes label selector for filtering resources within the specified namespace. An empty string disables filtering, allowing all resources to be selected.
 --timeout duration        Timeout. (default 5m0s)
 --wallet-key string       Hex-encoded private key for the Bee node wallet. Required.
 ```
@@ -385,13 +386,14 @@ Command **node-operator** uses <https://github.com/ethersphere/node-funder> tool
 It has following flags:
 
 ```console
---geth-url string     Endpoint to chain node. Required.
---help                help for node-operator
---min-native float    Minimum amount of chain native coins (xDAI) nodes should have.
---min-swarm float     Minimum amount of swarm tokens (xBZZ) nodes should have.
---namespace string    Kubernetes namespace to scan for scheduled pods.
---timeout duration    Timeout. Default is infinite.
---wallet-key string   Hex-encoded private key for the Bee node wallet. Required.
+--geth-url string         Endpoint to chain node. Required.
+--help                    help for node-operator
+--min-native float        Minimum amount of chain native coins (xDAI) nodes should have.
+--min-swarm float         Minimum amount of swarm tokens (xBZZ) nodes should have.
+--namespace string        Kubernetes namespace to scan for scheduled pods.
+--label-selector string   Kubernetes label selector for filtering resources within the specified namespace. An empty string disables filtering, allowing all resources to be selected.
+--timeout duration        Timeout. Default is infinite.
+--wallet-key string       Hex-encoded private key for the Bee node wallet. Required.
 ```
 
 example:
@@ -408,7 +410,7 @@ example:
 
 ```console
 --config string                 config file (default is $HOME/.beekeeper.yaml)
---config-dir string             config directory (default is $HOME/.beekeeper/) (default "C:\\Users\\ljubi\\.beekeeper")
+--config-dir string             config directory (default is $HOME/.beekeeper/)
 --config-git-branch string      Git branch (default "main")
 --config-git-password string    Git password or personal access tokens (needed for private repos)
 --config-git-repo string        Git repository with configurations (uses config directory when Git repo is not specified) (default "")

--- a/cmd/beekeeper/cmd/node_funder.go
+++ b/cmd/beekeeper/cmd/node_funder.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const ingressNodeFunderLabelSelector string = "beekeeper.ethswarm.org/node-funder=true"
+const nodeFunderLabelSelector string = "beekeeper.ethswarm.org/node-funder=true"
 
 func (c *command) initNodeFunderCmd() (err error) {
 	const (
@@ -110,7 +110,7 @@ func (c *command) initNodeFunderCmd() (err error) {
 	cmd.Flags().String(optionNameWalletKey, "", "Hex-encoded private key for the Bee node wallet. Required.")
 	cmd.Flags().Float64(optionNameMinNative, 0, "Minimum amount of chain native coins (xDAI) nodes should have.")
 	cmd.Flags().Float64(optionNameMinSwarm, 0, "Minimum amount of swarm tokens (xBZZ) nodes should have.")
-	cmd.Flags().String(optionNameLabelSelector, ingressNodeFunderLabelSelector, "Label selector for the ingress resources to be used for node-funder together with namespace. Empty string means no filtering.")
+	cmd.Flags().String(optionNameLabelSelector, nodeFunderLabelSelector, "Kubernetes label selector for filtering resources within the specified namespace. An empty string disables filtering, allowing all resources to be selected.")
 	cmd.Flags().Duration(optionNameTimeout, 5*time.Minute, "Timeout.")
 
 	c.root.AddCommand(cmd)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -105,6 +105,7 @@ node-groups:
       app.kubernetes.io/name: "bee"
       app.kubernetes.io/part-of: "bee"
       app.kubernetes.io/version: "latest"
+      beekeeper.ethswarm.org/node-funder: "true"
     node-selector:
       node-group: "private"
     persistence-enabled: false

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -117,6 +117,7 @@ node-groups:
       app.kubernetes.io/name: "bee"
       app.kubernetes.io/part-of: "bee"
       app.kubernetes.io/version: "latest"
+      beekeeper.ethswarm.org/node-funder: "true"
     node-selector:
       node-group: "local"
     persistence-enabled: false

--- a/config/testnet-giant.yaml
+++ b/config/testnet-giant.yaml
@@ -53,6 +53,7 @@ node-groups:
       app.kubernetes.io/name: "bee"
       app.kubernetes.io/part-of: "bee"
       app.kubernetes.io/version: "latest"
+      beekeeper.ethswarm.org/node-funder: "true"
     node-selector:
       node-group: "testnet-giant"
     persistence-enabled: false

--- a/config/testnet.yaml
+++ b/config/testnet.yaml
@@ -50,6 +50,7 @@ node-groups:
       app.kubernetes.io/name: "bee"
       app.kubernetes.io/part-of: "bee"
       app.kubernetes.io/version: "latest"
+      beekeeper.ethswarm.org/node-funder: "true"
     node-selector:
       node-group: "private"
     persistence-enabled: true


### PR DESCRIPTION
Refactor: Extract label-selector as a flag with default `beekeeper.ethswarm.org/node-funder=true`.

- Introduced a flag to specify the label selector for K8S resources used by node-funder and operator.
- Default label selector set to `beekeeper.ethswarm.org/node-funder=true`.
- If the label selector is an empty string, no filtering is applied.
- The label selector works in conjunction with the namespace for more granular resource selection.
