### PR TITLE
feat: extend manifest integration test

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -212,7 +212,7 @@ checks:
       max-pathname-length: 64
       postage-amount: 1000
       postage-depth: 17
-    timeout: 5m
+    timeout: 30m
     type: manifest
   networkavailability:
     options:

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -204,7 +204,7 @@ checks:
       max-pathname-length: 64
       postage-amount: 1000
       postage-depth: 17
-    timeout: 5m
+    timeout: 30m
     type: manifest
   ci-pingpong:
     options:

--- a/config/public-testnet.yaml
+++ b/config/public-testnet.yaml
@@ -79,7 +79,7 @@ checks:
       max-pathname-length: 64
       postage-amount: 140000000
       postage-depth: 17
-    timeout: 5m
+    timeout: 30m
     type: manifest
   pt-pss:
     options:

--- a/pkg/bee/api/api.go
+++ b/pkg/bee/api/api.go
@@ -34,6 +34,8 @@ const (
 	swarmSocSignatureHeader     = "Swarm-Soc-Signature"
 	swarmFeedIndexHeader        = "Swarm-Feed-Index"
 	swarmFeedIndexNextHeader    = "Swarm-Feed-Index-Next"
+	swarmIndexDocumentHeader    = "Swarm-Index-Document"
+	swarmErrorDocumentHeader    = "Swarm-Error-Document"
 )
 
 var userAgent = "beekeeper/" + beekeeper.Version
@@ -340,6 +342,10 @@ type UploadOptions struct {
 	BatchID           string
 	Direct            bool
 	ActHistoryAddress swarm.Address
+
+	// Dirs
+	IndexDocument string
+	ErrorDocument string
 }
 
 type DownloadOptions struct {

--- a/pkg/bee/api/dirs.go
+++ b/pkg/bee/api/dirs.go
@@ -30,6 +30,13 @@ func (s *DirsService) Upload(ctx context.Context, data io.Reader, size int64, o 
 	header.Set("swarm-collection", "True")
 	header.Set(postageStampBatchHeader, o.BatchID)
 
+	if o.IndexDocument != "" {
+		header.Set(swarmIndexDocumentHeader, o.IndexDocument)
+	}
+	if o.ErrorDocument != "" {
+		header.Set(swarmErrorDocumentHeader, o.ErrorDocument)
+	}
+
 	err = s.client.requestWithHeader(ctx, http.MethodPost, "/"+apiVersion+"/bzz", header, data, &resp)
 
 	return

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -77,10 +77,10 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	upClient := clients[0]
 	downClient := clients[1]
 
-	//err = c.checkWithoutSubDirs(ctx, rnd, o, upClient, downClient)
-	//if err != nil {
-	//	return fmt.Errorf("check without subdirs: %w", err)
-	//}
+	err = c.checkWithoutSubDirs(ctx, rnd, o, upClient, downClient)
+	if err != nil {
+		return fmt.Errorf("check without subdirs: %w", err)
+	}
 
 	err = c.checkWithSubDirs(ctx, rnd, o, upClient, downClient)
 	if err != nil {

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -168,7 +168,7 @@ func (c *Check) checkWithSubDirs(ctx context.Context, rnd *rand.Rand, o Options,
 	c.logger.Infof("collection uploaded: %s", tarFile.Address())
 	time.Sleep(3 * time.Second)
 
-	//push first version of website to the feed
+	// push first version of website to the feed
 	ref, err := upClient.UpdateFeedWithReference(ctx, signer, topic, 0, tarFile.Address(), api.UploadOptions{BatchID: batchID})
 	if err != nil {
 		return err

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -11,6 +11,8 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/ethersphere/bee/v2/pkg/crypto"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/beekeeper/pkg/bee"
 	"github.com/ethersphere/beekeeper/pkg/bee/api"
 	"github.com/ethersphere/beekeeper/pkg/beekeeper"
@@ -67,14 +69,34 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	}
 
 	rnd := random.PseudoGenerator(o.Seed)
+	perm := rnd.Perm(cluster.Size())
+	names := cluster.FullNodeNames()
 
-	c.logger.Infof("Seed: %d", o.Seed)
+	if len(names) < 2 {
+		return fmt.Errorf("not enough nodes to run feed check")
+	}
 
-	overlays, err := cluster.FlattenOverlays(ctx)
+	clients, err := cluster.NodesClients(ctx)
 	if err != nil {
 		return err
 	}
+	upClient := clients[names[perm[0]]]
+	downClient := clients[names[perm[1]]]
 
+	err = c.checkWithoutSubDirs(ctx, rnd, o, upClient, downClient)
+	if err != nil {
+		return fmt.Errorf("check without subdirs: %w", err)
+	}
+
+	err = c.checkWithSubDirs(ctx, rnd, o, upClient, downClient)
+	if err != nil {
+		return fmt.Errorf("check with subdirs: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Check) checkWithoutSubDirs(ctx context.Context, rnd *rand.Rand, o Options, upClient *bee.Client, downClient *bee.Client) error {
 	files, err := generateFiles(rnd, o.FilesInCollection, o.MaxPathnameLength)
 	if err != nil {
 		return err
@@ -86,55 +108,162 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	}
 
 	tarFile := bee.NewBufferFile("", tarReader)
-	clients, err := cluster.NodesClients(ctx)
+	batchID, err := upClient.GetOrCreateMutableBatch(ctx, o.PostageAmount, o.PostageDepth, o.PostageLabel)
+	if err != nil {
+		return fmt.Errorf("node %s: batch id %w", upClient.Name(), err)
+	}
+	c.logger.Infof("node %s: batch id %s", upClient.Name(), batchID)
+
+	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID}); err != nil {
+		return fmt.Errorf("node %d: %w", 0, err)
+	}
+
+	for _, file := range files {
+		if err := c.download(downClient, tarFile.Address(), &file, bee.File{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Check) checkWithSubDirs(ctx context.Context, rnd *rand.Rand, o Options, upClient *bee.Client, downClient *bee.Client) error {
+	privKey, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		return err
 	}
 
-	sortedNodes := cluster.FullNodeNames()
-	node := sortedNodes[0]
-
-	client := clients[node]
-
-	batchID, err := client.GetOrCreateMutableBatch(ctx, o.PostageAmount, o.PostageDepth, o.PostageLabel)
+	signer := crypto.NewDefaultSigner(privKey)
+	topic, err := crypto.LegacyKeccak256([]byte("my-website"))
 	if err != nil {
-		return fmt.Errorf("node %s: batch id %w", node, err)
-	}
-	c.logger.Infof("node %s: batch id %s", node, batchID)
-
-	if err := client.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID}); err != nil {
-		return fmt.Errorf("node %d: %w", 0, err)
+		return err
 	}
 
-	lastNode := sortedNodes[len(sortedNodes)-1]
+	batchID, err := upClient.GetOrCreateMutableBatch(ctx, o.PostageAmount, o.PostageDepth, o.PostageLabel)
+	if err != nil {
+		return fmt.Errorf("node %s: batch id %w", upClient.Name(), err)
+	}
+	c.logger.Infof("node %s: batch id %s", upClient.Name(), batchID)
+
+	rootFeedRef, err := upClient.CreateRootFeedManifest(ctx, signer, topic, api.UploadOptions{BatchID: batchID})
+	if err != nil {
+		return err
+	}
+	c.logger.Infof("root feed reference: %s", rootFeedRef.Reference)
+	time.Sleep(3 * time.Second)
+
+	paths := []string{"index.html", "assets/styles/styles.css", "assets/styles/images/image.png", "error.html"}
+	files, err := generateFilesWithPaths(rnd, paths, int(o.MaxPathnameLength))
+	if err != nil {
+		return err
+	}
+
+	tarReader, err := tarFiles(files)
+	tarFile := bee.NewBufferFile("", tarReader)
+	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID}); err != nil {
+		return err
+	}
+	c.logger.Infof("collection uploaded: %s", tarFile.Address())
+	time.Sleep(3 * time.Second)
+
+	//push first version of website to the feed
+	ref, err := upClient.UpdateFeedWithReference(ctx, signer, topic, 0, tarFile.Address(), api.UploadOptions{BatchID: batchID})
+	if err != nil {
+		return err
+	}
+	c.logger.Infof("feed updated: %s", ref.Reference)
+
+	// download root (index.html) from the feed
+	err = c.download(downClient, rootFeedRef.Reference, nil, files[0])
+	if err != nil {
+		return err
+	}
+
+	// update index.html file
+	tmp, err := generateFilesWithPaths(rnd, []string{"index.html"}, int(o.MaxPathnameLength))
+	if err != nil {
+		return err
+	}
+	files[0] = tmp[0]
+	tarReader, err = tarFiles(files)
+	tarFile = bee.NewBufferFile("", tarReader)
+	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID, Direct: true}); err != nil {
+		return err
+	}
+	time.Sleep(3 * time.Second)
+
+	// push 2nd version of website to the feed
+	ref, err = upClient.UpdateFeedWithReference(ctx, signer, topic, 1, tarFile.Address(), api.UploadOptions{BatchID: batchID})
+	if err != nil {
+		return err
+	}
+	c.logger.Infof("feed updated: %s", ref.Reference)
+
+	// download updated index.html from the feed
+	err = c.download(downClient, rootFeedRef.Reference, nil, files[0])
+	if err != nil {
+		return err
+	}
+
+	// download other paths and compare
+	for i := 0; i < len(files); i++ {
+		err = c.download(downClient, rootFeedRef.Reference, &files[i], files[0])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// download retrieves a file from the given address using the specified client.
+// If the file parameter is nil, it downloads the index file in the collection.
+func (c *Check) download(client *bee.Client, address swarm.Address, file *bee.File, indexFile bee.File) error {
+	fName := ""
+	if file != nil {
+		fName = file.Name()
+	}
+	c.logger.Infof("downloading file: %s/%s", address, fName)
+
 	try := 0
-
 DOWNLOAD:
 	time.Sleep(5 * time.Second)
 	try++
 	if try > 5 {
-		return errors.New("failed getting manifest files after too many retries")
+		return fmt.Errorf("failed getting manifest files after too many retries")
+	}
+	_, hash, err := client.DownloadManifestFile(context.Background(), address, fName)
+	if err != nil {
+		c.logger.Infof("node %s. Error retrieving file: %s", client.Name(), err.Error())
+		goto DOWNLOAD
 	}
 
-	for i, file := range files {
-		node := clients[lastNode]
-
-		size, hash, err := node.DownloadManifestFile(ctx, tarFile.Address(), file.Name())
-		if err != nil {
-			c.logger.Infof("Node %s. Error retrieving file: %v", lastNode, err)
-			goto DOWNLOAD
-		}
-
+	if file != nil {
 		if !bytes.Equal(file.Hash(), hash) {
-			c.logger.Infof("Node %s. File %d not retrieved successfully. Uploaded size: %d Downloaded size: %d Node: %s File: %s/%s", lastNode, i, file.Size(), size, overlays[lastNode].String(), tarFile.Address().String(), file.Name())
+			c.logger.Infof("node %s. File hash does not match", client.Name())
 			return errManifest
 		}
-
-		c.logger.Infof("Node %s. File %d retrieved successfully. Node: %s File: %s/%s", lastNode, i, overlays[lastNode].String(), tarFile.Address().String(), file.Name())
-		try = 0 // reset the retry counter for the next file
+	} else {
+		if !bytes.Equal(indexFile.Hash(), hash) {
+			c.logger.Infof("node %s. Index hash does not match", client.Name())
+			return errManifest
+		}
 	}
-
+	c.logger.Infof("node %s. File retrieved successfully", client.Name())
 	return nil
+}
+
+func generateFilesWithPaths(r *rand.Rand, paths []string, maxSize int) ([]bee.File, error) {
+	files := make([]bee.File, len(paths))
+	for i := 0; i < len(paths); i++ {
+		path := paths[i]
+		size := int64(r.Intn(maxSize)) + 1
+		file := bee.NewRandomFile(r, path, size)
+		err := file.CalculateHash()
+		if err != nil {
+			return nil, err
+		}
+		files[i] = file
+	}
+	return files, nil
 }
 
 func generateFiles(r *rand.Rand, filesCount int, maxPathnameLength int32) ([]bee.File, error) {

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -206,7 +206,7 @@ func (c *Check) checkWithSubDirs(ctx context.Context, rnd *rand.Rand, o Options,
 
 	// download other paths and compare
 	for i := 0; i < len(files); i++ {
-		err = c.download(downClient, rootFeedRef.Reference, &files[i], files[0])
+		err = c.download(downClient, tarFile.Address(), &files[i], files[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -70,6 +70,9 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 
 	rnd := random.PseudoGenerator(o.Seed)
 	clients, err := cluster.ShuffledFullNodeClients(ctx, rnd)
+	if err != nil {
+		return fmt.Errorf("node clients shuffle: %w", err)
+	}
 
 	if len(clients) < 2 {
 		return fmt.Errorf("not enough nodes to run feed check")
@@ -322,6 +325,6 @@ func tarFiles(files []bee.File) (*bytes.Buffer, error) {
 			return nil, err
 		}
 	}
-	
+
 	return &buf, nil
 }

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -162,7 +162,7 @@ func (c *Check) checkWithSubDirs(ctx context.Context, rnd *rand.Rand, o Options,
 		return err
 	}
 	tarFile := bee.NewBufferFile("", tarReader)
-	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID}); err != nil {
+	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID, IndexDocument: "index.html"}); err != nil {
 		return err
 	}
 	c.logger.Infof("collection uploaded: %s", tarFile.Address())
@@ -181,18 +181,18 @@ func (c *Check) checkWithSubDirs(ctx context.Context, rnd *rand.Rand, o Options,
 		return err
 	}
 
-	// update index.html file
-	tmp, err := generateFilesWithPaths(rnd, []string{"index.html"}, int(o.MaxPathnameLength))
+	// update  website files
+	files, err = generateFilesWithPaths(rnd, paths, int(o.MaxPathnameLength))
 	if err != nil {
 		return err
 	}
-	files[0] = tmp[0]
+
 	tarReader, err = tarFiles(files)
 	if err != nil {
 		return err
 	}
 	tarFile = bee.NewBufferFile("", tarReader)
-	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID, Direct: true}); err != nil {
+	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID, IndexDocument: "index.html"}); err != nil {
 		return err
 	}
 	time.Sleep(3 * time.Second)

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -69,8 +69,8 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	}
 
 	rnd := random.PseudoGenerator(o.Seed)
-	perm := rnd.Perm(cluster.Size())
 	names := cluster.FullNodeNames()
+	perm := rnd.Perm(len(names))
 
 	if len(names) < 2 {
 		return fmt.Errorf("not enough nodes to run feed check")

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -158,6 +158,9 @@ func (c *Check) checkWithSubDirs(ctx context.Context, rnd *rand.Rand, o Options,
 	}
 
 	tarReader, err := tarFiles(files)
+	if err != nil {
+		return err
+	}
 	tarFile := bee.NewBufferFile("", tarReader)
 	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID}); err != nil {
 		return err
@@ -185,6 +188,9 @@ func (c *Check) checkWithSubDirs(ctx context.Context, rnd *rand.Rand, o Options,
 	}
 	files[0] = tmp[0]
 	tarReader, err = tarFiles(files)
+	if err != nil {
+		return err
+	}
 	tarFile = bee.NewBufferFile("", tarReader)
 	if err := upClient.UploadCollection(ctx, &tarFile, api.UploadOptions{BatchID: batchID, Direct: true}); err != nil {
 		return err

--- a/pkg/orchestration/cluster.go
+++ b/pkg/orchestration/cluster.go
@@ -23,6 +23,7 @@ type Cluster interface {
 	FlattenSettlements(ctx context.Context) (settlements NodeGroupSettlements, err error)
 	FlattenTopologies(ctx context.Context) (topologies map[string]bee.Topology, err error)
 	FullNodeNames() (names []string)
+	ShuffledFullNodeClients(ctx context.Context, r *rand.Rand) ([]*bee.Client, error)
 	GlobalReplicationFactor(ctx context.Context, a swarm.Address) (grf int, err error)
 	LightNodeNames() (names []string)
 	Name() string

--- a/pkg/orchestration/k8s/cluster.go
+++ b/pkg/orchestration/k8s/cluster.go
@@ -233,6 +233,22 @@ func (c *Cluster) FullNodeNames() (names []string) {
 	return
 }
 
+// ShuffledFullNodeClients returns a list of full node clients shuffled
+func (c *Cluster) ShuffledFullNodeClients(ctx context.Context, r *rand.Rand) ([]*bee.Client, error) {
+	cls, err := c.NodesClients(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var res []*bee.Client
+	for _, cl := range cls {
+		res = append(res, cl)
+	}
+	r.Shuffle(len(res), func(i, j int) {
+		res[i], res[j] = res[j], res[i]
+	})
+	return res, nil
+}
+
 // NodesClients returns map of node's clients in the cluster excluding stopped nodes
 func (c *Cluster) NodesClients(ctx context.Context) (map[string]*bee.Client, error) {
 	clients := make(map[string]*bee.Client)

--- a/pkg/orchestration/k8s/cluster.go
+++ b/pkg/orchestration/k8s/cluster.go
@@ -235,13 +235,12 @@ func (c *Cluster) FullNodeNames() (names []string) {
 
 // ShuffledFullNodeClients returns a list of full node clients shuffled
 func (c *Cluster) ShuffledFullNodeClients(ctx context.Context, r *rand.Rand) ([]*bee.Client, error) {
-	cls, err := c.NodesClients(ctx)
-	if err != nil {
-		return nil, err
-	}
 	var res []*bee.Client
-	for _, cl := range cls {
-		res = append(res, cl)
+	for _, node := range c.Nodes() {
+		cfg := node.Config()
+		if cfg.FullNode && !cfg.BootnodeMode {
+			res = append(res, node.Client())
+		}
 	}
 	r.Shuffle(len(res), func(i, j int) {
 		res[i], res[j] = res[j], res[i]


### PR DESCRIPTION
Uses feeds to test updates to a website

1. It creates a root feed manifest
2. To make an update to the feed, it uploads a tar website with some index.html and other files. Then uses this reference in the feed update.
3. It then tries to download the website via the root feed reference. It should resolve to the index.html
4. To update the website, we push another update to the feed with the new tar and then try to download it again via the root feed reference.
5. Lastly, it tries to download the other files in the website directly. e.g `b25c89a401d9f26811680476619a1eb4a4e189e614bc6161cbfd8b343214917b/assets/styles/styles.css`