### PR TITLE
fix: gsoc via pushsync

### DIFF
--- a/pkg/bee/client.go
+++ b/pkg/bee/client.go
@@ -348,11 +348,7 @@ func (c *Client) ClosestPeer(ctx context.Context, binId uint8, skipList []swarm.
 		return swarm.ZeroAddress, err
 	}
 
-	bin, ok := t.Bins[fmt.Sprintf("bin_%d", binId)]
-	if !ok {
-		return swarm.ZeroAddress, fmt.Errorf("no such bin")
-	}
-
+	bin := t.Bins[fmt.Sprintf("bin_%d", binId)]
 	if len(bin.ConnectedPeers) == 0 {
 		return swarm.ZeroAddress, nil
 	}

--- a/pkg/check/gsoc/gsoc.go
+++ b/pkg/check/gsoc/gsoc.go
@@ -77,7 +77,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	}
 
 	uploadClient := fullNodeClients[0]
-	listenClient, err := cluster.ClosetFullNodeClient(ctx, uploadClient, rnd)
+	listenClient, err := cluster.ClosestFullNodeClient(ctx, uploadClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/check/gsoc/gsoc.go
+++ b/pkg/check/gsoc/gsoc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethersphere/beekeeper/pkg/beekeeper"
 	"github.com/ethersphere/beekeeper/pkg/logging"
 	"github.com/ethersphere/beekeeper/pkg/orchestration"
+	"github.com/ethersphere/beekeeper/pkg/random"
 	"github.com/ethersphere/beekeeper/pkg/wslistener"
 	"golang.org/x/sync/errgroup"
 )
@@ -65,18 +66,21 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 		return fmt.Errorf("invalid options type")
 	}
 
-	fullNodeNames := cluster.FullNodeNames()
-	clients, err := cluster.NodesClients(ctx)
+	rnd := random.PseudoGenerator(time.Now().UnixNano())
+	fullNodeClients, err := cluster.ShuffledFullNodeClients(ctx, rnd)
 	if err != nil {
 		return err
 	}
 
-	if len(fullNodeNames) < 2 {
+	if len(fullNodeClients) < 2 {
 		return fmt.Errorf("gsoc test require at least 2 full nodes")
 	}
 
-	uploadClient := clients[fullNodeNames[0]]
-	listenClient := clients[fullNodeNames[1]]
+	uploadClient := fullNodeClients[0]
+	listenClient, err := cluster.ClosetFullNodeClient(ctx, uploadClient, rnd)
+	if err != nil {
+		return err
+	}
 
 	batches := make([]string, 2)
 	for i := 0; i < 2; i++ {
@@ -92,14 +96,14 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	c.logger.Infof("send messages with different postage batches sequentially...")
 	err = run(ctx, uploadClient, listenClient, batches, c.logger, false)
 	if err != nil {
-		return err
+		return fmt.Errorf("sequential: %w", err)
 	}
 	c.logger.Infof("done")
 
 	c.logger.Infof("send messages with different postage batches parallel...")
 	err = run(ctx, uploadClient, listenClient, batches, c.logger, true)
 	if err != nil {
-		return err
+		return fmt.Errorf("parallel: %w", err)
 	}
 	c.logger.Infof("done")
 

--- a/pkg/orchestration/cluster.go
+++ b/pkg/orchestration/cluster.go
@@ -36,6 +36,7 @@ type Cluster interface {
 	ShuffledFullNodeClients(ctx context.Context, r *rand.Rand) ([]*bee.Client, error)
 	Size() (size int)
 	Topologies(ctx context.Context) (topologies ClusterTopologies, err error)
+	ClosetFullNodeClient(ctx context.Context, s *bee.Client, r *rand.Rand) (*bee.Client, error)
 }
 
 // ClusterOptions represents Bee cluster options

--- a/pkg/orchestration/cluster.go
+++ b/pkg/orchestration/cluster.go
@@ -36,7 +36,7 @@ type Cluster interface {
 	ShuffledFullNodeClients(ctx context.Context, r *rand.Rand) ([]*bee.Client, error)
 	Size() (size int)
 	Topologies(ctx context.Context) (topologies ClusterTopologies, err error)
-	ClosetFullNodeClient(ctx context.Context, s *bee.Client, r *rand.Rand) (*bee.Client, error)
+	ClosestFullNodeClient(ctx context.Context, s *bee.Client) (*bee.Client, error)
 }
 
 // ClusterOptions represents Bee cluster options

--- a/pkg/orchestration/k8s/cluster.go
+++ b/pkg/orchestration/k8s/cluster.go
@@ -476,7 +476,7 @@ func (c *Cluster) ClosestFullNodeClient(ctx context.Context, s *bee.Client) (*be
 				return nil, fmt.Errorf("peer overlay %s not found in address map", peer.Address.String())
 			}
 			cfg := node.Config()
-			if !cfg.FullNode && cfg.BootnodeMode {
+			if !cfg.FullNode || cfg.BootnodeMode {
 				continue
 			}
 			o2, err := node.Client().Overlay(ctx)

--- a/pkg/orchestration/k8s/cluster.go
+++ b/pkg/orchestration/k8s/cluster.go
@@ -462,7 +462,7 @@ func (c *Cluster) ClosestFullNodeClient(ctx context.Context, s *bee.Client) (*be
 	}
 
 	minProx := uint8(math.MaxUint8)
-	o1, err := s.Overlay(ctx)
+	overlay, err := s.Overlay(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -479,11 +479,7 @@ func (c *Cluster) ClosestFullNodeClient(ctx context.Context, s *bee.Client) (*be
 			if !cfg.FullNode || cfg.BootnodeMode {
 				continue
 			}
-			o2, err := node.Client().Overlay(ctx)
-			if err != nil {
-				return nil, err
-			}
-			prox := swarm.Proximity(o1.Bytes(), o2.Bytes())
+			prox := swarm.Proximity(overlay.Bytes(), peer.Address.Bytes())
 			if prox < minProx {
 				minProx = prox
 				closest = node.Client()


### PR DESCRIPTION
A SOC can arrive at a node via push sync or pull sync.
With pull sync, you might not get all chunk versions because the newer version would have overridden the older one on the upstream node by the time you sync. 

This issue doesn't exist when the listener node receives the chunk via pushsync as it will receive the chunk immediately after it is pushed. Effectively receiving all versions.

This PR ensures that the listener gets the chunk via push sync and such, we can verify consistently that it receives all versions.