### PR TITLE
fix: gsoc listner node selection

### DIFF
--- a/pkg/check/gsoc/gsoc.go
+++ b/pkg/check/gsoc/gsoc.go
@@ -121,9 +121,9 @@ func run(ctx context.Context, uploadClient *bee.Client, listenClient *bee.Client
 	if err != nil {
 		return err
 	}
-	depth := 6
-	logger.Infof("gsoc: mining resource id for overlay=%s, depth=%d", addresses.Overlay, depth)
-	resourceId, socAddress, err := mineResourceId(ctx, addresses.Overlay, privKey, depth)
+	prefixMatchDepth := 6
+	logger.Infof("gsoc: mining resource id for overlay=%s, prefixMatchDepth=%d", addresses.Overlay, prefixMatchDepth)
+	resourceId, socAddress, err := mineResourceId(ctx, addresses.Overlay, privKey, prefixMatchDepth)
 	if err != nil {
 		return err
 	}

--- a/pkg/check/gsoc/gsoc.go
+++ b/pkg/check/gsoc/gsoc.go
@@ -121,7 +121,9 @@ func run(ctx context.Context, uploadClient *bee.Client, listenClient *bee.Client
 	if err != nil {
 		return err
 	}
-	resourceId, socAddress, err := mineResourceId(ctx, addresses.Overlay, privKey, 1)
+	depth := 6
+	logger.Infof("gsoc: mining resource id for overlay=%s, depth=%d", addresses.Overlay, depth)
+	resourceId, socAddress, err := mineResourceId(ctx, addresses.Overlay, privKey, depth)
 	if err != nil {
 		return err
 	}
@@ -169,7 +171,7 @@ func run(ctx context.Context, uploadClient *bee.Client, listenClient *bee.Client
 	}
 
 	select {
-	case <-time.After(1 * time.Minute):
+	case <-time.After(3 * time.Minute):
 		return fmt.Errorf("timeout: not all messages received")
 	case <-done:
 	}

--- a/pkg/check/pss/pss.go
+++ b/pkg/check/pss/pss.go
@@ -139,7 +139,7 @@ func (c *Check) testPss(nodeAName, nodeBName string, clients map[string]*bee.Cli
 
 	for {
 		select {
-		case <-time.After(1 * time.Minute):
+		case <-time.After(3 * time.Minute):
 			return fmt.Errorf("correct message not received after %s", 1*time.Minute)
 		case msg, ok := <-ch:
 			if !ok {


### PR DESCRIPTION
 Increase the depth for mining the soc addresses so that the listener node is picked more accurately when pushing out the chunk on the uploader.

Also increases the timeout to receive all messages.

