### PR TITLE
chore: update config for pt-testnet-load

### DIFF
--- a/config/public-testnet.yaml
+++ b/config/public-testnet.yaml
@@ -159,10 +159,10 @@ checks:
   pt-testnet-load:
     options:
       content-size: 50000000
-      postage-ttl: 720h
+      postage-ttl: 336h
       postage-depth: 22
       postage-label: test-label
-      duration: 720h
+      duration: 12h
       uploader-count: 2
       downloader-count: 0
       max-committed-depth: 2
@@ -173,7 +173,7 @@ checks:
       download-groups:
         - bee-3
         - bee-4
-    timeout: 721h
+    timeout: 13h
     type: load
   pt-smoke:
     options:

--- a/pkg/bee/api/api.go
+++ b/pkg/bee/api/api.go
@@ -60,11 +60,6 @@ type Client struct {
 	Tags        *TagsService
 }
 
-// ClientOptions holds optional parameters for the Client.
-type ClientOptions struct {
-	HTTPClient *http.Client
-}
-
 // NewClient constructs a new Client.
 func NewClient(apiURL *url.URL, httpClient *http.Client) (*Client, error) {
 	if httpClient == nil {
@@ -137,11 +132,10 @@ func (c *Client) request(ctx context.Context, method, path string, body io.Reade
 		return err
 	}
 
-	req, err := http.NewRequest(method, fullURL, body)
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, body)
 	if err != nil {
 		return err
 	}
-	req = req.WithContext(ctx)
 
 	if body != nil {
 		req.Header.Set("Content-Type", contentType)

--- a/pkg/bee/api/feed.go
+++ b/pkg/bee/api/feed.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 
 	"github.com/ethersphere/bee/v2/pkg/crypto"
@@ -75,7 +76,7 @@ func (f *FeedService) UpdateWithRootChunk(ctx context.Context, signer crypto.Sig
 	}
 	index := make([]byte, 8)
 	binary.BigEndian.PutUint64(index, i)
-	idBytes, err := crypto.LegacyKeccak256(append(append([]byte{}, topic...), index...))
+	idBytes, err := crypto.LegacyKeccak256(slices.Concat(topic, index))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -299,7 +299,7 @@ func generateFilesWithPaths(r *rand.Rand, paths []string, maxSize int) ([]bee.Fi
 func generateFiles(r *rand.Rand, filesCount int, maxPathnameLength int32) ([]bee.File, error) {
 	files := make([]bee.File, filesCount)
 
-	for i := 0; i < filesCount; i++ {
+	for i := range filesCount {
 		pathnameLength := int64(r.Int31n(maxPathnameLength-1)) + 1 // ensure path with length of at least one
 
 		b := make([]byte, pathnameLength)

--- a/pkg/check/smoke/load.go
+++ b/pkg/check/smoke/load.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"errors"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -67,7 +68,7 @@ func (c *LoadCheck) run(ctx context.Context, cluster orchestration.Cluster, o Op
 
 	clients, err := cluster.NodesClients(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("get clients: %w", err)
 	}
 
 	test := &test{clients: clients, logger: c.logger}


### PR DESCRIPTION
The `pt-testnet-load` in the `beekeeper` namespace is configured with `--timeout=13h`. Previously, if the timeout elapsed, it would exit with an error. This change ensures that when the `duration` elapses, the check is considered successful, preventing an error exit.