### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/check/fullconnectivity/fullconnectivity.go
+++ b/pkg/check/fullconnectivity/fullconnectivity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/beekeeper/pkg/beekeeper"
@@ -100,13 +101,7 @@ func (c *Check) checkFullNodesConnectivity(ctx context.Context, cluster orchestr
 }
 
 func isBootNode(group string, bootnodes []string) bool {
-	for _, b := range bootnodes {
-		if group == b {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(bootnodes, group)
 }
 
 func (c *Check) checkLightNodesConnectivity(ctx context.Context, cluster orchestration.Cluster, skipNodes []string) (err error) {

--- a/pkg/orchestration/k8s/cluster.go
+++ b/pkg/orchestration/k8s/cluster.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"slices"
 
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/beekeeper/pkg/bee"
@@ -315,12 +316,7 @@ func (c *Cluster) FlattenOverlays(ctx context.Context, exclude ...string) (map[s
 }
 
 func containsName(s []string, e string) bool {
-	for i := range s {
-		if s[i] == e {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, e)
 }
 
 // Peers returns peers of all nodes in the cluster

--- a/pkg/orchestration/k8s/nodegroup.go
+++ b/pkg/orchestration/k8s/nodegroup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1000,11 +1001,5 @@ func (g *NodeGroup) setNode(name string, n orchestration.Node) (err error) {
 }
 
 func contains(list []string, find string) bool {
-	for _, v := range list {
-		if v == find {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(list, find)
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.