### PR TITLE
fix: set different batch expiration times for each check

### DIFF
--- a/config/public-testnet.yaml
+++ b/config/public-testnet.yaml
@@ -57,7 +57,7 @@ checks:
   pt-retrieval:
     options:
       chunks-per-node: 3
-      postage-ttl: 336h
+      postage-ttl: 480h # 20 days
       postage-depth: 22
       postage-label: test-label
       upload-node-count: 3
@@ -81,7 +81,7 @@ checks:
     options:
       files-in-collection: 10
       max-pathname-length: 64
-      postage-ttl: 336h
+      postage-ttl: 240h # 10 days
       postage-depth: 22
       postage-label: test-label
     timeout: 30m
@@ -90,7 +90,7 @@ checks:
     options:
       count: 3
       address-prefix: 2
-      postage-ttl: 336h
+      postage-ttl: 384h # 16 days
       postage-depth: 22
       postage-label: test-label
       request-timeout: 10m
@@ -98,7 +98,7 @@ checks:
     type: pss
   pt-soc:
     options:
-      postage-ttl: 336h
+      postage-ttl: 528h # 22 days
       postage-depth: 22
       postage-label: test-label
       request-timeout: 5m
@@ -108,7 +108,7 @@ checks:
     options:
       chunks-per-node: 3
       mode: chunks
-      postage-ttl: 336h
+      postage-ttl: 192h # 8 days
       postage-depth: 22
       postage-label: test-label
       retries: 5
@@ -130,14 +130,14 @@ checks:
       postage-new-depth: 18
   pt-gsoc:
     options:
-      postage-ttl: 336h
+      postage-ttl: 336h # 14 days
       postage-depth: 22
       postage-label: test-label
     timeout: 10m
     type: gsoc
   pt-feed:
     options:
-      postage-ttl: 336h
+      postage-ttl: 288h # 12 days
       postage-depth: 22
       postage-label: test-label
     timeout: 30m
@@ -148,7 +148,7 @@ checks:
     type: feed
   pt-redundancy:
     options:
-      postage-ttl: 336h
+      postage-ttl: 432h # 18 days
       postage-depth: 22
       postage-label: test-label
       seed:
@@ -158,7 +158,7 @@ checks:
   pt-testnet-load:
     options:
       content-size: 50000000
-      postage-ttl: 336h
+      postage-ttl: 408h # 17 days
       postage-depth: 22
       postage-label: test-label
       duration: 12h
@@ -177,9 +177,9 @@ checks:
   pt-smoke:
     options:
       content-size: 50000000
-      postage-ttl: 336h
+      postage-ttl: 360h # 15 days
       postage-depth: 22
       postage-label: test-label
-      duration: 720h
-    timeout: 721h
+      duration: 360h
+    timeout: 361h
     type: smoke

--- a/pkg/check/gsoc/gsoc.go
+++ b/pkg/check/gsoc/gsoc.go
@@ -83,7 +83,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	}
 
 	batches := make([]string, 2)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		c.logger.Infof("gsoc: creating postage batch. duration=%d, depth=%d, label=%s", o.PostageTTL, o.PostageDepth, o.PostageLabel)
 		batchID, err := uploadClient.GetOrCreateMutableBatch(ctx, o.PostageTTL, o.PostageDepth, o.PostageLabel)
 		if err != nil {
@@ -192,15 +192,17 @@ func uploadSoc(ctx context.Context, client *bee.Client, payload string, resource
 	if err != nil {
 		return fmt.Errorf("make soc: %w", err)
 	}
+
 	_, err = client.UploadSOC(ctx, d.Owner, hex.EncodeToString(resourceId), d.Sig, d.Data, batchID)
 	if err != nil {
 		return fmt.Errorf("upload soc: %w", err)
 	}
+
 	return nil
 }
 
 func runInSequence(ctx context.Context, client *bee.Client, numChunks int, batches []string, resourceId []byte, privKey *ecdsa.PrivateKey, logger logging.Logger) error {
-	for i := 0; i < numChunks; i++ {
+	for i := range numChunks {
 		payload := fmt.Sprintf("data %d", i)
 		logger.Infof("gsoc: submitting soc to node=%s, payload=%s", client.Name(), payload)
 		err := uploadSoc(ctx, client, payload, resourceId, batches[i%2], privKey)
@@ -208,12 +210,13 @@ func runInSequence(ctx context.Context, client *bee.Client, numChunks int, batch
 			return err
 		}
 	}
+
 	return nil
 }
 
 func runInParallel(ctx context.Context, client *bee.Client, numChunks int, batches []string, resourceId []byte, privKey *ecdsa.PrivateKey, logger logging.Logger) error {
 	var errG errgroup.Group
-	for i := 0; i < numChunks; i++ {
+	for i := range numChunks {
 		errG.Go(func() error {
 			payload := fmt.Sprintf("data %d", i)
 			logger.Infof("gsoc: submitting soc to node=%s, payload=%s", client.Name(), payload)
@@ -225,7 +228,7 @@ func runInParallel(ctx context.Context, client *bee.Client, numChunks int, batch
 
 func getTargetNeighborhood(address swarm.Address, depth int) (string, error) {
 	var targetNeighborhood string
-	for i := 0; i < depth; i++ {
+	for i := range depth {
 		hexChar := address.String()[i : i+1]
 		value, err := strconv.ParseUint(hexChar, 16, 4)
 		if err != nil {

--- a/pkg/check/pushsync/pushsync.go
+++ b/pkg/check/pushsync/pushsync.go
@@ -94,8 +94,7 @@ func (c *Check) defaultCheck(ctx context.Context, cluster orchestration.Cluster,
 	}
 
 	sortedNodes := cluster.NodeNames()
-	for i := 0; i < o.UploadNodeCount; i++ {
-
+	for i := range o.UploadNodeCount {
 		nodeName := sortedNodes[i]
 		client := clients[nodeName]
 
@@ -105,7 +104,7 @@ func (c *Check) defaultCheck(ctx context.Context, cluster orchestration.Cluster,
 		}
 		c.logger.Infof("node %s: batch id %s", nodeName, batchID)
 
-		for j := 0; j < o.ChunksPerNode; j++ {
+		for range o.ChunksPerNode {
 			chunk, err := bee.NewRandomChunk(rnds[i], c.logger)
 			if err != nil {
 				return fmt.Errorf("node %s: %w", nodeName, err)

--- a/pkg/check/retrieval/retrieval.go
+++ b/pkg/check/retrieval/retrieval.go
@@ -77,7 +77,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 
 	nodes := cluster.FullNodeNames()
 
-	for i := 0; i < o.UploadNodeCount; i++ {
+	for i := range o.UploadNodeCount {
 		uploadNode := clients[nodes[i]]
 		downloadNodeIndex := (i + 1) % len(nodes) // download from the next node
 		downloadNode := clients[nodes[downloadNodeIndex]]
@@ -88,7 +88,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 		}
 		c.logger.Infof("node %s: created batched id %s", uploadNode.Name(), batchID)
 
-		for j := 0; j < o.ChunksPerNode; j++ {
+		for j := range o.ChunksPerNode {
 			// time upload
 			t0 := time.Now()
 

--- a/pkg/check/smoke/smoke.go
+++ b/pkg/check/smoke/smoke.go
@@ -104,8 +104,6 @@ func (c *Check) run(ctx context.Context, cluster orchestration.Cluster, o Option
 		return err
 	}
 
-	time.Sleep(5 * time.Second) // Wait for the nodes to warmup.
-
 	test := &test{clients: clients, logger: c.logger}
 
 	c.metrics.UploadSize.Set(float64(o.ContentSize))
@@ -154,7 +152,8 @@ func (c *Check) run(ctx context.Context, cluster orchestration.Cluster, o Option
 			txCtx    context.Context
 			txCancel context.CancelFunc = func() {}
 		)
-		for retries := 0; retries < 3; retries++ {
+
+		for range 3 {
 			txCancel()
 
 			uploaded = false
@@ -202,7 +201,8 @@ func (c *Check) run(ctx context.Context, cluster orchestration.Cluster, o Option
 			rxCtx    context.Context
 			rxCancel context.CancelFunc = func() {}
 		)
-		for retries := 0; retries < 3; retries++ {
+
+		for range 3 {
 			rxCancel()
 
 			select {

--- a/pkg/config/check.go
+++ b/pkg/config/check.go
@@ -656,7 +656,7 @@ func applyCheckConfig(global CheckGlobalConfig, local, opts interface{}) (err er
 	ov := reflect.Indirect(reflect.ValueOf(opts).Elem())
 	ot := reflect.TypeOf(opts).Elem()
 
-	for i := 0; i < lv.NumField(); i++ {
+	for i := range lv.NumField() {
 		fieldName := lt.Field(i).Name
 		switch fieldName {
 		case "Seed":

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -18,7 +18,7 @@ func PseudoGenerator(seed int64) (g *rand.Rand) {
 // goroutines, so that predictability of the generators can be maintained.
 func PseudoGenerators(seed int64, n int) (g []*rand.Rand) {
 	rnd := rand.New(rand.NewSource(seed))
-	for i := 0; i < n; i++ {
+	for range n {
 		g = append(g, rand.New(rand.NewSource(rnd.Int63())))
 	}
 	return


### PR DESCRIPTION
Since Beekeeper picks random nodes per check, this will distribute batch expirations across the cluster, reducing simultaneous batch creation spikes.