### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/bee/postage.go
+++ b/pkg/bee/postage.go
@@ -9,11 +9,7 @@ import (
 const MinimumBatchDepth = 2
 
 func EstimatePostageBatchDepth(contentLength int64) uint64 {
-	depth := uint64(math.Log2(float64(calculateNumberOfChunks(contentLength, false))))
-	if depth < MinimumBatchDepth {
-		depth = MinimumBatchDepth
-	}
-	return depth
+	return max(uint64(math.Log2(float64(calculateNumberOfChunks(contentLength, false)))), MinimumBatchDepth)
 }
 
 // calculateNumberOfChunks calculates the number of chunks in an arbitrary


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.