### PR TITLE
chore: modernize codebase for go 1.25

### DIFF
--- a/cmd/beekeeper/cmd/metrics.go
+++ b/cmd/beekeeper/cmd/metrics.go
@@ -17,11 +17,8 @@ func newMetricsPusher(pusherAddress, job string, logger logging.Logger) (*push.P
 	killC := make(chan struct{})
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-
 	// start period flusher
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-killC:
@@ -32,7 +29,7 @@ func newMetricsPusher(pusherAddress, job string, logger logging.Logger) (*push.P
 				}
 			}
 		}
-	}()
+	})
 	cleanupFn := func() {
 		close(killC)
 		wg.Wait()

--- a/pkg/bee/api/api.go
+++ b/pkg/bee/api/api.go
@@ -115,7 +115,7 @@ func newClient(apiURL *url.URL, httpClient *http.Client) (c *Client) {
 // body, creates an HTTP request with provided method on a path with required
 // headers and decodes request body if the v argument is not nil and content type is
 // application/json.
-func (c *Client) requestJSON(ctx context.Context, method, path string, body, v interface{}) (err error) {
+func (c *Client) requestJSON(ctx context.Context, method, path string, body, v any) (err error) {
 	var bodyBuffer io.ReadWriter
 	if body != nil {
 		bodyBuffer = new(bytes.Buffer)
@@ -136,7 +136,7 @@ func (c *Client) getFullURL(path string) (string, error) {
 }
 
 // request handles the HTTP request response cycle.
-func (c *Client) request(ctx context.Context, method, path string, body io.Reader, v interface{}) (err error) {
+func (c *Client) request(ctx context.Context, method, path string, body io.Reader, v any) (err error) {
 	fullURL, err := c.getFullURL(path)
 	if err != nil {
 		return err
@@ -171,7 +171,7 @@ func (c *Client) request(ctx context.Context, method, path string, body io.Reade
 
 // encodeJSON writes a JSON-encoded v object to the provided writer with
 // SetEscapeHTML set to false.
-func encodeJSON(w io.Writer, v interface{}) (err error) {
+func encodeJSON(w io.Writer, v any) (err error) {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	return enc.Encode(v)
@@ -238,7 +238,7 @@ func (c *Client) requestDataGetHeader(ctx context.Context, method, path string, 
 }
 
 // requestWithHeader handles the HTTP request response cycle.
-func (c *Client) requestWithHeader(ctx context.Context, method, path string, header http.Header, body io.Reader, v interface{}, headerParser ...func(http.Header)) (err error) {
+func (c *Client) requestWithHeader(ctx context.Context, method, path string, header http.Header, body io.Reader, v any, headerParser ...func(http.Header)) (err error) {
 	fullURL, err := c.getFullURL(path)
 	if err != nil {
 		return err

--- a/pkg/bee/client.go
+++ b/pkg/bee/client.go
@@ -460,7 +460,7 @@ func (c *Client) CreatePostageBatch(ctx context.Context, amount int64, depth uin
 	exists := false
 	usable := false
 	// wait for the stamp to become usable
-	for i := 0; i < 900; i++ {
+	for range 900 {
 		time.Sleep(1 * time.Second)
 		state, err := c.api.Postage.PostageStamp(ctx, id)
 		if err != nil {
@@ -558,7 +558,7 @@ func (c *Client) TopUpPostageBatch(ctx context.Context, batchID string, amount i
 		return err
 	}
 
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		time.Sleep(time.Second)
 
 		b, err := c.PostageStamp(ctx, batchID)
@@ -587,7 +587,7 @@ func (c *Client) DilutePostageBatch(ctx context.Context, batchID string, depth u
 		return err
 	}
 
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		time.Sleep(time.Second)
 
 		b, err := c.api.Postage.PostageStamp(ctx, batchID)

--- a/pkg/beekeeper/beekeeper.go
+++ b/pkg/beekeeper/beekeeper.go
@@ -10,5 +10,5 @@ import (
 // needs to expose metrics should implement the metrics.Reporter
 // interface.
 type Action interface {
-	Run(ctx context.Context, cluster orchestration.Cluster, o interface{}) (err error)
+	Run(ctx context.Context, cluster orchestration.Cluster, o any) (err error)
 }

--- a/pkg/beekeeper/tracing.go
+++ b/pkg/beekeeper/tracing.go
@@ -26,7 +26,7 @@ func NewActionMiddleware(tracer opentracing.Tracer, action Action, actionName st
 }
 
 // Run implements beekeeper.Action
-func (am *actionMiddleware) Run(ctx context.Context, cluster orchestration.Cluster, o interface{}) (err error) {
+func (am *actionMiddleware) Run(ctx context.Context, cluster orchestration.Cluster, o any) (err error) {
 	span := createSpan(ctx, am.tracer, am.actionName)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)

--- a/pkg/check/act/act.go
+++ b/pkg/check/act/act.go
@@ -54,7 +54,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 }
 
 // Run executes act check
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/balances/balances.go
+++ b/pkg/check/balances/balances.go
@@ -3,6 +3,7 @@ package balances
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/ethersphere/beekeeper/pkg/beekeeper"
@@ -56,7 +57,7 @@ func NewCheck(log logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")
@@ -151,7 +152,7 @@ func dryRun(ctx context.Context, cluster orchestration.Cluster, log logging.Logg
 }
 
 func expectBalancesHaveChanged(balances, newBalances orchestration.NodeGroupBalances, log logging.Logger) error {
-	for t := 0; t < 5; t++ {
+	for t := range 5 {
 		sleepTime := 2 * time.Duration(t) * time.Second
 		log.Infof("Waiting %s before checking balances", sleepTime)
 		time.Sleep(sleepTime)
@@ -212,9 +213,7 @@ func balancesHaveChanged(current, previous orchestration.NodeGroupBalances, log 
 func flattenBalances(b orchestration.ClusterBalances) map[string]map[string]int64 {
 	res := make(map[string]map[string]int64)
 	for _, ngb := range b {
-		for n, balances := range ngb {
-			res[n] = balances
-		}
+		maps.Copy(res, ngb)
 	}
 	return res
 }

--- a/pkg/check/cashout/cashout.go
+++ b/pkg/check/cashout/cashout.go
@@ -51,7 +51,7 @@ type CashoutAction struct {
 }
 
 // Check executes settlements check
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")
@@ -111,7 +111,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 	}
 
 LOOP:
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		time.Sleep(5 * time.Second)
 
 		for _, action := range actions {

--- a/pkg/check/datadurability/datadurability.go
+++ b/pkg/check/datadurability/datadurability.go
@@ -48,7 +48,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 
 // Run runs the check
 // It downloads a file that contains a list of chunks and then attempts to download each chunk in the file.
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, o interface{}) error {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, o any) error {
 	opts, ok := o.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")
@@ -140,7 +140,7 @@ func fetchFile(ctx context.Context, logger logging.Logger, ref swarm.Address, cl
 		nodes = append(nodes, node)
 	}
 
-	for i := 0; i < maxAttempts; i++ {
+	for i := range maxAttempts {
 		node := nodes[i%len(nodes)]
 		d, err := node.Client().DownloadFileBytes(ctx, ref, nil)
 		if err != nil {

--- a/pkg/check/feed/feed.go
+++ b/pkg/check/feed/feed.go
@@ -51,7 +51,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/fileretrieval/fileretrieval.go
+++ b/pkg/check/fileretrieval/fileretrieval.go
@@ -60,7 +60,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/fullconnectivity/fullconnectivity.go
+++ b/pkg/check/fullconnectivity/fullconnectivity.go
@@ -40,7 +40,7 @@ func NewDefaultOptions() Options {
 
 var errFullConnectivity = errors.New("full connectivity")
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	lightNodes := opts.(Options).LightNodeNames
 	bootNodes := opts.(Options).BootNodeNames
 	if err := c.checkFullNodesConnectivity(ctx, cluster, lightNodes, bootNodes); err != nil {

--- a/pkg/check/gc/reserve.go
+++ b/pkg/check/gc/reserve.go
@@ -135,7 +135,7 @@ A little bit about how the numbers make sense:
   checks on the pinning API.
 */
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/gsoc/gsoc.go
+++ b/pkg/check/gsoc/gsoc.go
@@ -60,7 +60,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")
@@ -178,7 +178,7 @@ func run(ctx context.Context, uploadClient *bee.Client, listenClient *bee.Client
 
 	receivedMtx.Lock()
 	defer receivedMtx.Unlock()
-	for i := 0; i < numChunks; i++ {
+	for i := range numChunks {
 		want := fmt.Sprintf("data %d", i)
 		if !received[want] {
 			return fmt.Errorf("message '%s' not received", want)

--- a/pkg/check/kademlia/kademlia.go
+++ b/pkg/check/kademlia/kademlia.go
@@ -40,7 +40,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/load/load.go
+++ b/pkg/check/load/load.go
@@ -79,7 +79,7 @@ func NewCheck(log logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) error {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) error {
 	o, ok := opts.(Options)
 	if !ok {
 		return errors.New("invalid options type")

--- a/pkg/check/longavailability/longavailability.go
+++ b/pkg/check/longavailability/longavailability.go
@@ -48,7 +48,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, o interface{}) error {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, o any) error {
 	opts, ok := o.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/manifest/manifest.go
+++ b/pkg/check/manifest/manifest.go
@@ -60,7 +60,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")
@@ -258,7 +258,7 @@ func (c *Check) downloadAndVerify(ctx context.Context, client *bee.Client, addre
 	}
 	c.logger.Infof("downloading file: %s/%s", address, fName)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		select {
 		case <-time.After(5 * time.Second):
 			_, hash, err := client.DownloadManifestFile(ctx, address, fName)

--- a/pkg/check/networkavailability/check.go
+++ b/pkg/check/networkavailability/check.go
@@ -56,7 +56,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 }
 
 // Run creates file of specified size that is uploaded and downloaded.
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) error {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) error {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")
@@ -162,7 +162,7 @@ func neighborhoods(bits int) []swarm.Address {
 
 	ret := make([]swarm.Address, 0, max)
 
-	for i := 0; i < max; i++ {
+	for i := range max {
 		buf := make([]byte, 4)
 		binary.LittleEndian.PutUint32(buf, uint32(i))
 

--- a/pkg/check/peercount/peercount.go
+++ b/pkg/check/peercount/peercount.go
@@ -23,7 +23,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	overlays, err := cluster.Overlays(ctx)
 	if err != nil {
 		return err

--- a/pkg/check/pingpong/pingpong.go
+++ b/pkg/check/pingpong/pingpong.go
@@ -39,7 +39,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 }
 
 // Run executes ping check
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, _ interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, _ any) (err error) {
 	nodeGroups := cluster.NodeGroups()
 	for _, ng := range nodeGroups {
 		nodesClients, err := ng.NodesClients(ctx)
@@ -48,7 +48,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, _ interf
 		}
 
 		for n := range nodeStream(ctx, nodesClients) { // TODO: confirm use case for nodeStream(ctx, ng.NodesClientsAll(ctx))
-			for t := 0; t < 5; t++ {
+			for t := range 5 {
 				time.Sleep(2 * time.Duration(t) * time.Second)
 
 				if n.Error != nil {

--- a/pkg/check/postage/postage.go
+++ b/pkg/check/postage/postage.go
@@ -48,7 +48,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/pss/pss.go
+++ b/pkg/check/pss/pss.go
@@ -57,7 +57,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/pullsync/pullsync.go
+++ b/pkg/check/pullsync/pullsync.go
@@ -57,7 +57,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 
 var errPullSync = errors.New("pull sync")
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/pushsync/check_lightnode.go
+++ b/pkg/check/pushsync/check_lightnode.go
@@ -32,7 +32,7 @@ func checkLightChunks(ctx context.Context, cluster orchestration.Cluster, o Opti
 	lightNodes := cluster.LightNodeNames()
 
 	// prepare postage batches
-	for i := 0; i < len(lightNodes); i++ {
+	for i := range lightNodes {
 		nodeName := lightNodes[i]
 		batchID, err := clients[nodeName].GetOrCreateMutableBatch(ctx, o.PostageTTL, o.PostageDepth, o.PostageLabel)
 		if err != nil {
@@ -61,7 +61,7 @@ func checkLightChunks(ctx context.Context, cluster orchestration.Cluster, o Opti
 
 			var ref swarm.Address
 
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				ref, err = uploader.UploadChunk(ctx, chunk.Data(), api.UploadOptions{BatchID: batchID})
 				if err == nil {
 					break
@@ -83,7 +83,7 @@ func checkLightChunks(ctx context.Context, cluster orchestration.Cluster, o Opti
 			l.Infof("closest node %s overlay %s", closestName, closestAddress)
 
 			var synced bool
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				synced, _ = clients[closestName].HasChunk(ctx, ref)
 				if synced {
 					break

--- a/pkg/check/pushsync/pushsync.go
+++ b/pkg/check/pushsync/pushsync.go
@@ -62,7 +62,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/redundancy/redundancy.go
+++ b/pkg/check/redundancy/redundancy.go
@@ -58,7 +58,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, o interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, o any) (err error) {
 	opts, ok := o.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/retrieval/retrieval.go
+++ b/pkg/check/retrieval/retrieval.go
@@ -57,7 +57,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 var errRetrieval = errors.New("retrieval")
 
 // Run uploads given chunks on cluster and checks pushsync ability of the cluster
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/runner.go
+++ b/pkg/check/runner.go
@@ -96,7 +96,7 @@ func (c *CheckRunner) Run(ctx context.Context, checks []string) error {
 
 	// run checks
 	for _, check := range validatedChecks {
-		c.logger.WithFields(map[string]interface{}{
+		c.logger.WithFields(map[string]any{
 			"type":    check.typeName,
 			"options": fmt.Sprintf("%+v", check.options),
 		}).Infof("running check: %s", check.name)
@@ -104,7 +104,7 @@ func (c *CheckRunner) Run(ctx context.Context, checks []string) error {
 		err := check.Run(ctx, c.cluster)
 		if err != nil {
 			hasFailures = true
-			c.logger.WithFields(map[string]interface{}{
+			c.logger.WithFields(map[string]any{
 				"type":  check.typeName,
 				"error": err,
 			}).Errorf("'%s' check failed", check.name)
@@ -132,7 +132,7 @@ type checkRun struct {
 	name     string
 	typeName string
 	action   beekeeper.Action
-	options  interface{}
+	options  any
 	timeout  *time.Duration
 }
 

--- a/pkg/check/settlements/settlements.go
+++ b/pkg/check/settlements/settlements.go
@@ -67,7 +67,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")
@@ -136,7 +136,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 		settlementsValid := false
 		// validate settlements after uploading a file
 		previousSettlements = settlements
-		for t := 0; t < 7; t++ {
+		for t := range 7 {
 			time.Sleep(2 * time.Duration(t) * time.Second)
 
 			accounting, err = cluster.FlattenAccounting(ctx)
@@ -185,7 +185,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts int
 		settlementsValid = false
 		// validate settlements after downloading a file
 		previousSettlements = settlements
-		for t := 0; t < 7; t++ {
+		for t := range 7 {
 			time.Sleep(2 * time.Duration(t) * time.Second)
 
 			accounting, err = cluster.FlattenAccounting(ctx)

--- a/pkg/check/smoke/smoke.go
+++ b/pkg/check/smoke/smoke.go
@@ -72,7 +72,7 @@ func NewCheck(log logging.Logger) beekeeper.Action {
 }
 
 // Run creates file of specified size that is uploaded and downloaded.
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) error {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) error {
 	o, ok := opts.(Options)
 	if !ok {
 		return errors.New("invalid options type")

--- a/pkg/check/soc/soc.go
+++ b/pkg/check/soc/soc.go
@@ -54,7 +54,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/check/stake/stake.go
+++ b/pkg/check/stake/stake.go
@@ -49,7 +49,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 
 var zero = big.NewInt(0)
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return err

--- a/pkg/check/withdraw/withdraw.go
+++ b/pkg/check/withdraw/withdraw.go
@@ -37,7 +37,7 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 	}
 }
 
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/config/check.go
+++ b/pkg/config/check.go
@@ -48,8 +48,8 @@ type Check struct {
 
 // CheckType is used for linking beekeeper actions with check and it's proper options
 type CheckType struct {
-	NewAction  func(logging.Logger) beekeeper.Action               // links check with beekeeper action
-	NewOptions func(CheckGlobalConfig, Check) (interface{}, error) // check options
+	NewAction  func(logging.Logger) beekeeper.Action       // links check with beekeeper action
+	NewOptions func(CheckGlobalConfig, Check) (any, error) // check options
 }
 
 // CheckGlobalConfig represents global configs for all checks
@@ -62,7 +62,7 @@ type CheckGlobalConfig struct {
 var Checks = map[string]CheckType{
 	"act": {
 		NewAction: act.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				FileName     *string        `yaml:"file-name"`
 				FileSize     *int64         `yaml:"file-size"`
@@ -84,7 +84,7 @@ var Checks = map[string]CheckType{
 	},
 	"balances": {
 		NewAction: balances.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				DryRun             *bool          `yaml:"dry-run"`
 				FileName           *string        `yaml:"file-name"`
@@ -111,7 +111,7 @@ var Checks = map[string]CheckType{
 	},
 	"cashout": {
 		NewAction: cashout.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				NodeGroup *string `yaml:"node-group"`
 			})
@@ -129,7 +129,7 @@ var Checks = map[string]CheckType{
 	},
 	"file-retrieval": {
 		NewAction: fileretrieval.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				FileName        *string        `yaml:"file-name"`
 				FileSize        *int64         `yaml:"file-size"`
@@ -155,7 +155,7 @@ var Checks = map[string]CheckType{
 	},
 	"full-connectivity": {
 		NewAction: fullconnectivity.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				LightNodeNames *[]string `yaml:"group-1"`
 				FullNodeNames  *[]string `yaml:"group-2"`
@@ -175,7 +175,7 @@ var Checks = map[string]CheckType{
 	},
 	"gc": {
 		NewAction: gc.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				CacheSize    *int    `yaml:"cache-size"`
 				GasPrice     *string `yaml:"gas-price"`
@@ -197,7 +197,7 @@ var Checks = map[string]CheckType{
 	},
 	"kademlia": {
 		NewAction: kademlia.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				Dynamic *bool `yaml:"dynamic"`
 			})
@@ -215,7 +215,7 @@ var Checks = map[string]CheckType{
 	},
 	"manifest": {
 		NewAction: manifest.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				FilesInCollection *int           `yaml:"files-in-collection"`
 				GasPrice          *string        `yaml:"gas-price"`
@@ -239,20 +239,20 @@ var Checks = map[string]CheckType{
 	},
 	"peer-count": {
 		NewAction: peercount.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			return nil, nil
 		},
 	},
 	"pingpong": {
 		NewAction: pingpong.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			opts := pingpong.NewDefaultOptions()
 			return opts, nil
 		},
 	},
 	"pss": {
 		NewAction: pss.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				Count          *int64         `yaml:"count"`
 				AddressPrefix  *int           `yaml:"address-prefix"`
@@ -277,7 +277,7 @@ var Checks = map[string]CheckType{
 	},
 	"pullsync": {
 		NewAction: pullsync.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				ChunksPerNode              *int           `yaml:"chunks-per-node"`
 				GasPrice                   *string        `yaml:"gas-price"`
@@ -301,7 +301,7 @@ var Checks = map[string]CheckType{
 	},
 	"pushsync": {
 		NewAction: pushsync.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				ChunksPerNode     *int           `yaml:"chunks-per-node"`
 				GasPrice          *string        `yaml:"gas-price"`
@@ -329,7 +329,7 @@ var Checks = map[string]CheckType{
 	},
 	"retrieval": {
 		NewAction: retrieval.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				ChunksPerNode   *int           `yaml:"chunks-per-node"`
 				PostageTTL      *time.Duration `yaml:"postage-ttl"`
@@ -352,7 +352,7 @@ var Checks = map[string]CheckType{
 	},
 	"settlements": {
 		NewAction: settlements.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				DryRun             *bool          `yaml:"dry-run"`
 				ExpectSettlements  *bool          `yaml:"expect-settlements"`
@@ -381,7 +381,7 @@ var Checks = map[string]CheckType{
 	},
 	"smoke": {
 		NewAction: smoke.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				ContentSize   *int64         `yaml:"content-size"`
 				FileSizes     *[]int64       `yaml:"file-sizes"`
@@ -414,7 +414,7 @@ var Checks = map[string]CheckType{
 	},
 	"load": {
 		NewAction: load.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				ContentSize             *int64         `yaml:"content-size"`
 				RndSeed                 *int64         `yaml:"rnd-seed"`
@@ -448,7 +448,7 @@ var Checks = map[string]CheckType{
 	},
 	"soc": {
 		NewAction: soc.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				GasPrice       *string        `yaml:"gas-price"`
 				PostageTTL     *time.Duration `yaml:"postage-ttl"`
@@ -470,7 +470,7 @@ var Checks = map[string]CheckType{
 	},
 	"postage": {
 		NewAction: postage.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				GasPrice           *string `yaml:"gas-price"`
 				PostageAmount      *int64  `yaml:"postage-amount"`
@@ -491,7 +491,7 @@ var Checks = map[string]CheckType{
 	},
 	"stake": {
 		NewAction: stake.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				Amount             *big.Int `yaml:"amount"`
 				InsufficientAmount *big.Int `yaml:"insufficient-amount"`
@@ -511,7 +511,7 @@ var Checks = map[string]CheckType{
 	},
 	"longavailability": {
 		NewAction: longavailability.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				RndSeed      *int64         `yaml:"rnd-seed"`
 				RetryCount   *int64         `yaml:"retry-count"`
@@ -533,7 +533,7 @@ var Checks = map[string]CheckType{
 	},
 	"networkavailability": {
 		NewAction: networkavailability.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				RndSeed       *int64         `yaml:"rnd-seed"`
 				PostageTTL    *time.Duration `yaml:"postage-ttl"`
@@ -555,7 +555,7 @@ var Checks = map[string]CheckType{
 	},
 	"datadurability": {
 		NewAction: datadurability.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				Ref         *string `yaml:"ref"`
 				Concurrency *int    `yaml:"concurrency"`
@@ -575,7 +575,7 @@ var Checks = map[string]CheckType{
 	},
 	"redundancy": {
 		NewAction: redundancy.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				DataSize     *int           `yaml:"data-size"`
 				PostageDepth *int           `yaml:"postage-depth"`
@@ -597,7 +597,7 @@ var Checks = map[string]CheckType{
 	},
 	"withdraw": {
 		NewAction: withdraw.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				TargetAddr *string `yaml:"target-address"`
 			})
@@ -615,7 +615,7 @@ var Checks = map[string]CheckType{
 	},
 	"gsoc": {
 		NewAction: gsoc.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				PostageTTL   *time.Duration `yaml:"postage-ttl"`
 				PostageDepth *uint64        `yaml:"postage-depth"`
@@ -635,7 +635,7 @@ var Checks = map[string]CheckType{
 	},
 	"feed": {
 		NewAction: feed.NewCheck,
-		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (interface{}, error) {
+		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
 			checkOpts := new(struct {
 				PostageTTL   *time.Duration `yaml:"postage-ttl"`
 				PostageDepth *uint64        `yaml:"postage-depth"`
@@ -658,7 +658,7 @@ var Checks = map[string]CheckType{
 }
 
 // applyCheckConfig merges global and local options into default options
-func applyCheckConfig(global CheckGlobalConfig, local, opts interface{}) (err error) {
+func applyCheckConfig(global CheckGlobalConfig, local, opts any) (err error) {
 	lv := reflect.ValueOf(local).Elem()
 	lt := reflect.TypeOf(local).Elem()
 	ov := reflect.Indirect(reflect.ValueOf(opts).Elem())

--- a/pkg/config/simulation.go
+++ b/pkg/config/simulation.go
@@ -24,7 +24,7 @@ type Simulation struct {
 // SimulationType is used for linking beekeeper actions with simulation and it's proper options
 type SimulationType struct {
 	NewAction  func(logging.Logger) beekeeper.Action
-	NewOptions func(SimulationGlobalConfig, Simulation) (interface{}, error)
+	NewOptions func(SimulationGlobalConfig, Simulation) (any, error)
 }
 
 // SimulationGlobalConfig represents global configs for all simulations
@@ -36,7 +36,7 @@ type SimulationGlobalConfig struct {
 var Simulations = map[string]SimulationType{
 	"upload": {
 		NewAction: upload.NewSimulation,
-		NewOptions: func(simulationGlobalConfig SimulationGlobalConfig, simulation Simulation) (interface{}, error) {
+		NewOptions: func(simulationGlobalConfig SimulationGlobalConfig, simulation Simulation) (any, error) {
 			simulationOpts := new(struct {
 				FileCount            *int64         `yaml:"file-count"`
 				GasPrice             *string        `yaml:"gas-price"`
@@ -67,7 +67,7 @@ var Simulations = map[string]SimulationType{
 	},
 	"retrieval": {
 		NewAction: retrieval.NewSimulation,
-		NewOptions: func(simulationGlobalConfig SimulationGlobalConfig, simulation Simulation) (interface{}, error) {
+		NewOptions: func(simulationGlobalConfig SimulationGlobalConfig, simulation Simulation) (any, error) {
 			simulationOpts := new(struct {
 				ChunksPerNode   *int           `yaml:"chunks-per-node"`
 				GasPrice        *string        `yaml:"gas-price"`
@@ -92,7 +92,7 @@ var Simulations = map[string]SimulationType{
 	},
 	"pushsync": {
 		NewAction: pushsync.NewSimulation,
-		NewOptions: func(simulationGlobalConfig SimulationGlobalConfig, simulation Simulation) (interface{}, error) {
+		NewOptions: func(simulationGlobalConfig SimulationGlobalConfig, simulation Simulation) (any, error) {
 			simulationOpts := new(struct {
 				GasPrice         *string  `yaml:"gas-price"`
 				PostageAmount    *int64   `yaml:"postage-amount"`
@@ -119,7 +119,7 @@ var Simulations = map[string]SimulationType{
 }
 
 // applySimulationConfig merges given, global and default simulation options
-func applySimulationConfig(global SimulationGlobalConfig, local, opts interface{}) (err error) {
+func applySimulationConfig(global SimulationGlobalConfig, local, opts any) (err error) {
 	lv := reflect.ValueOf(local).Elem()
 	lt := reflect.TypeOf(local).Elem()
 	ov := reflect.Indirect(reflect.ValueOf(opts).Elem())

--- a/pkg/k8s/customresource/ingressroute/types.go
+++ b/pkg/k8s/customresource/ingressroute/types.go
@@ -19,14 +19,14 @@ type IngressRouteSpec struct {
 
 type IngressRoute struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	Spec IngressRouteSpec `json:"spec"`
 }
 
 type IngressRouteList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 
 	Items []IngressRoute `json:"items"`
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -14,19 +14,19 @@ import (
 )
 
 type Logger interface {
-	Tracef(format string, args ...interface{})
-	Trace(args ...interface{})
-	Debugf(format string, args ...interface{})
-	Debug(args ...interface{})
-	Infof(format string, args ...interface{})
-	Info(args ...interface{})
-	Warningf(format string, args ...interface{})
-	Warning(args ...interface{})
-	Errorf(format string, args ...interface{})
-	Error(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Fatal(args ...interface{})
-	WithField(key string, value interface{}) *logrus.Entry
+	Tracef(format string, args ...any)
+	Trace(args ...any)
+	Debugf(format string, args ...any)
+	Debug(args ...any)
+	Infof(format string, args ...any)
+	Info(args ...any)
+	Warningf(format string, args ...any)
+	Warning(args ...any)
+	Errorf(format string, args ...any)
+	Error(args ...any)
+	Fatalf(format string, args ...any)
+	Fatal(args ...any)
+	WithField(key string, value any) *logrus.Entry
 	WithFields(fields logrus.Fields) *logrus.Entry
 	WriterLevel(logrus.Level) *io.PipeWriter
 	NewEntry() *logrus.Entry

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,7 +15,7 @@ type Reporter interface {
 	Report() []prometheus.Collector
 }
 
-func PrometheusCollectorsFromFields(i interface{}) (cs []prometheus.Collector) {
+func PrometheusCollectorsFromFields(i any) (cs []prometheus.Collector) {
 	v := reflect.Indirect(reflect.ValueOf(i))
 	for i := 0; i < v.NumField(); i++ {
 		if !v.Field(i).CanInterface() {

--- a/pkg/orchestration/k8s/cluster.go
+++ b/pkg/orchestration/k8s/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"maps"
 	"math/rand"
 	"net/http"
 	"slices"
@@ -189,9 +190,7 @@ func (c *Cluster) Namespace() string {
 // NodeGroups returns map of node groups in the cluster
 func (c *Cluster) NodeGroups() (l map[string]orchestration.NodeGroup) {
 	nodeGroups := make(map[string]orchestration.NodeGroup)
-	for k, v := range c.nodeGroups {
-		nodeGroups[k] = v
-	}
+	maps.Copy(nodeGroups, c.nodeGroups)
 	return nodeGroups
 }
 
@@ -208,9 +207,7 @@ func (c *Cluster) NodeGroup(name string) (ng orchestration.NodeGroup, err error)
 func (c *Cluster) Nodes() map[string]orchestration.Node {
 	n := make(map[string]orchestration.Node)
 	for _, ng := range c.NodeGroups() {
-		for k, v := range ng.Nodes() {
-			n[k] = v
-		}
+		maps.Copy(n, ng.Nodes())
 	}
 	return n
 }
@@ -270,9 +267,7 @@ func (c *Cluster) NodesClients(ctx context.Context) (map[string]*bee.Client, err
 		if err != nil {
 			return nil, fmt.Errorf("nodes clients: %w", err)
 		}
-		for n, client := range ngc {
-			clients[n] = client
-		}
+		maps.Copy(clients, ngc)
 	}
 	return clients, nil
 }

--- a/pkg/orchestration/k8s/nodegroup.go
+++ b/pkg/orchestration/k8s/nodegroup.go
@@ -636,17 +636,14 @@ func (g *NodeGroup) PeersStream(ctx context.Context) (<-chan PeersStreamMsg, err
 			continue
 		}
 
-		wg.Add(1)
-		go func(n string, c *bee.Client) {
-			defer wg.Done()
-
-			a, err := c.Peers(ctx)
+		wg.Go(func() {
+			a, err := v.Client().Peers(ctx)
 			peersStream <- PeersStreamMsg{
-				Name:  n,
+				Name:  k,
 				Peers: a,
 				Error: err,
 			}
-		}(k, v.Client())
+		})
 	}
 
 	go func() {

--- a/pkg/random/random_test.go
+++ b/pkg/random/random_test.go
@@ -399,9 +399,9 @@ func TestGetRandom_Concurrent(t *testing.T) {
 	results := make(chan int, numGoroutines*valuesPerGoroutine)
 	errors := make(chan error, numGoroutines*valuesPerGoroutine)
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
-			for j := 0; j < valuesPerGoroutine; j++ {
+			for range valuesPerGoroutine {
 				result, err := g.GetRandom(1, 100)
 				if err != nil {
 					errors <- err
@@ -439,7 +439,7 @@ func TestGetRandom_ZeroRange(t *testing.T) {
 		g := random.NewGenerator(false) // non-unique
 
 		// Generate multiple values when both min and max are 0
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			result, err := g.GetRandom(0, 0)
 			if err != nil {
 				t.Fatalf("GetRandom(0, 0) failed: %v", err)

--- a/pkg/simulate/pushsync/pushsync.go
+++ b/pkg/simulate/pushsync/pushsync.go
@@ -75,7 +75,7 @@ func NewSimulation(logger logging.Logger) beekeeper.Action {
 }
 
 // Run executes upload stress
-func (s *Simulation) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (s *Simulation) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/simulate/pushsync/pushsync_test.go
+++ b/pkg/simulate/pushsync/pushsync_test.go
@@ -83,7 +83,7 @@ func isArrSame(a, b []string) bool {
 		return false
 	}
 
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		if a[i] != b[i] {
 			return false
 		}

--- a/pkg/simulate/retrieval/retrieval.go
+++ b/pkg/simulate/retrieval/retrieval.go
@@ -58,7 +58,7 @@ func NewSimulation(logger logging.Logger) beekeeper.Action {
 }
 
 // Run executes retrieval simulation
-func (s *Simulation) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (s *Simulation) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	o, ok := opts.(Options)
 	if !ok {
 		return fmt.Errorf("invalid options type")

--- a/pkg/simulate/upload/upload.go
+++ b/pkg/simulate/upload/upload.go
@@ -71,7 +71,7 @@ func NewSimulation(logger logging.Logger) beekeeper.Action {
 }
 
 // Run executes upload stress
-func (s *Simulation) Run(ctx context.Context, cluster orchestration.Cluster, opts interface{}) (err error) {
+func (s *Simulation) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
 	s.logger.Info("running upload simulation")
 	o, ok := opts.(Options)
 	if !ok {
@@ -208,7 +208,7 @@ func (s *Simulation) Run(ctx context.Context, cluster orchestration.Cluster, opt
 
 // randomPick randomly picks n elements from the list, and returns lists of picked elements
 func randomPick(rnd *rand.Rand, list []string, n int) (picked []string) {
-	for i := 0; i < n; i++ {
+	for range n {
 		index := rnd.Intn(len(list))
 		picked = append(picked, list[index])
 		list = append(list[:index], list[index+1:]...)

--- a/pkg/stamper/stamper.go
+++ b/pkg/stamper/stamper.go
@@ -77,7 +77,7 @@ func (s *Client) Create(ctx context.Context, duration time.Duration, depth uint1
 		return fmt.Errorf("depth must be greater than %d", postage.BucketDepth)
 	}
 
-	s.log.WithFields(map[string]interface{}{
+	s.log.WithFields(map[string]any{
 		"duration": duration,
 		"depth":    depth,
 	}).Info("creating postage batch on nodes")
@@ -103,7 +103,7 @@ func (s *Client) Create(ctx context.Context, duration time.Duration, depth uint1
 
 // Dilute dilutes a postage batch.
 func (s *Client) Dilute(ctx context.Context, usageThreshold float64, dilutionDepth uint16, opts ...Option) error {
-	s.log.WithFields(map[string]interface{}{
+	s.log.WithFields(map[string]any{
 		"usageThreshold": usageThreshold,
 		"dilutionDepth":  dilutionDepth,
 	}).Info("diluting postage batch on nodes")
@@ -130,7 +130,7 @@ func (s *Client) Dilute(ctx context.Context, usageThreshold float64, dilutionDep
 
 // Set sets the topup and dilution parameters.
 func (s *Client) Set(ctx context.Context, ttlThreshold time.Duration, topupTo time.Duration, usageThreshold float64, dilutionDepth uint16, opts ...Option) error {
-	s.log.WithFields(map[string]interface{}{
+	s.log.WithFields(map[string]any{
 		"ttlThreshold":   ttlThreshold,
 		"topupTo":        topupTo,
 		"usageThreshold": usageThreshold,
@@ -172,7 +172,7 @@ func (s *Client) Set(ctx context.Context, ttlThreshold time.Duration, topupTo ti
 
 // Topup tops up a postage batch.
 func (s *Client) Topup(ctx context.Context, ttlThreshold time.Duration, topupTo time.Duration, opts ...Option) (err error) {
-	s.log.WithFields(map[string]interface{}{
+	s.log.WithFields(map[string]any{
 		"ttlThreshold": ttlThreshold,
 		"topupTo":      topupTo,
 	}).Info("topup postage batch on nodes")

--- a/pkg/swap/block.go
+++ b/pkg/swap/block.go
@@ -100,10 +100,10 @@ func (g *GethClient) FetchBlockTime(ctx context.Context, opts ...Option) (int64,
 }
 
 type rpcRequest struct {
-	ID      string        `json:"id"`
-	JsonRPC string        `json:"jsonrpc"`
-	Method  string        `json:"method"`
-	Params  []interface{} `json:"params"`
+	ID      string `json:"id"`
+	JsonRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
 }
 
 func (g *GethClient) fetchLatestBlockNumber(ctx context.Context) (int64, error) {
@@ -144,7 +144,7 @@ func (g *GethClient) fetchBlockTimestamp(ctx context.Context, blockNumber int64)
 		ID:      "1",
 		JsonRPC: "2.0",
 		Method:  "eth_getBlockByNumber",
-		Params:  []interface{}{fmt.Sprintf("0x%x", blockNumber), false},
+		Params:  []any{fmt.Sprintf("0x%x", blockNumber), false},
 	}
 
 	resp := new(struct {

--- a/pkg/swap/http.go
+++ b/pkg/swap/http.go
@@ -18,7 +18,7 @@ const contentType = "application/json; charset=utf-8"
 // body, creates an HTTP request with provided method on a path with required
 // headers and decodes request body if the v argument is not nil and content type is
 // application/json.
-func (c *GethClient) requestJSON(ctx context.Context, httpClient *http.Client, method, path string, body, v interface{}) (err error) {
+func (c *GethClient) requestJSON(ctx context.Context, httpClient *http.Client, method, path string, body, v any) (err error) {
 	var bodyBuffer io.ReadWriter
 	if body != nil {
 		bodyBuffer = new(bytes.Buffer)
@@ -39,7 +39,7 @@ func (c *GethClient) getFullURL(path string) (string, error) {
 }
 
 // request handles the HTTP request response cycle.
-func (c *GethClient) request(ctx context.Context, httpClient *http.Client, method, path string, body io.Reader, v interface{}) (err error) {
+func (c *GethClient) request(ctx context.Context, httpClient *http.Client, method, path string, body io.Reader, v any) (err error) {
 	fullURL, err := c.getFullURL(path)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (c *GethClient) request(ctx context.Context, httpClient *http.Client, metho
 
 // encodeJSON writes a JSON-encoded v object to the provided writer with
 // SetEscapeHTML set to false.
-func encodeJSON(w io.Writer, v interface{}) (err error) {
+func encodeJSON(w io.Writer, v any) (err error) {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	return enc.Encode(v)


### PR DESCRIPTION
Similar to PR https://github.com/ethersphere/bee/pull/5236

Uses `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix ./...` to update the code