### PR TITLE
chore: use strings.Builder and reflect.TypeFor to simplify code

### DIFF
--- a/pkg/check/gsoc/gsoc.go
+++ b/pkg/check/gsoc/gsoc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -227,16 +228,16 @@ func runInParallel(ctx context.Context, client *bee.Client, numChunks int, batch
 }
 
 func getTargetNeighborhood(address swarm.Address, depth int) (string, error) {
-	var targetNeighborhood string
+	var targetNeighborhood strings.Builder
 	for i := range depth {
 		hexChar := address.String()[i : i+1]
 		value, err := strconv.ParseUint(hexChar, 16, 4)
 		if err != nil {
 			return "", err
 		}
-		targetNeighborhood += fmt.Sprintf("%04b", value)
+		targetNeighborhood.WriteString(fmt.Sprintf("%04b", value))
 	}
-	return targetNeighborhood, nil
+	return targetNeighborhood.String(), nil
 }
 
 func mineResourceId(ctx context.Context, overlay swarm.Address, privKey *ecdsa.PrivateKey, depth int) ([]byte, swarm.Address, error) {

--- a/pkg/check/kademlia/kademlia.go
+++ b/pkg/check/kademlia/kademlia.go
@@ -130,16 +130,17 @@ func checkKademliaD(topologies orchestration.ClusterTopologies, logger logging.L
 	}
 
 	if len(culprits) > 0 {
-		errmsg := ""
+		var errmsg strings.Builder
 		for node, c := range culprits {
-			msg := fmt.Sprintf("node %s expected connection to:\n", node)
+			var msg strings.Builder
+			msg.WriteString(fmt.Sprintf("node %s expected connection to:\n", node))
 			for _, addr := range c {
-				msg += addr.String() + "\n"
+				msg.WriteString(addr.String() + "\n")
 			}
 
-			errmsg += msg
+			errmsg.WriteString(msg.String())
 		}
-		return errors.New(errmsg)
+		return errors.New(errmsg.String())
 	}
 
 	return nil

--- a/pkg/config/bee.go
+++ b/pkg/config/bee.go
@@ -70,7 +70,7 @@ func (b BeeConfig) GetParentName() string {
 // Export exports BeeConfig to orchestration.Config
 func (b *BeeConfig) Export() (config orchestration.Config) {
 	localVal := reflect.ValueOf(b).Elem()
-	localType := reflect.TypeOf(b).Elem()
+	localType := reflect.TypeFor[BeeConfig]()
 	remoteVal := reflect.ValueOf(&config).Elem()
 
 	for i := range localVal.NumField() {

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -57,7 +57,7 @@ type NodeEndpoint struct {
 // Export exports Cluster to orchestration.ClusterOptions, skipping all other extra fields
 func (c *Cluster) Export() (o orchestration.ClusterOptions) {
 	localVal := reflect.ValueOf(c).Elem()
-	localType := reflect.TypeOf(c).Elem()
+	localType := reflect.TypeFor[Cluster]()
 	remoteVal := reflect.ValueOf(&o).Elem()
 
 	for i := 0; i < localVal.NumField(); i++ {

--- a/pkg/config/funding.go
+++ b/pkg/config/funding.go
@@ -16,7 +16,7 @@ type Funding struct {
 // Export exports Funding to orchestration.FundingOptions
 func (f *Funding) Export() (o orchestration.FundingOptions) {
 	localVal := reflect.ValueOf(f).Elem()
-	localType := reflect.TypeOf(f).Elem()
+	localType := reflect.TypeFor[Funding]()
 	remoteVal := reflect.ValueOf(&o).Elem()
 
 	for i := 0; i < localVal.NumField(); i++ {

--- a/pkg/config/nodegroup.go
+++ b/pkg/config/nodegroup.go
@@ -41,7 +41,7 @@ func (b NodeGroup) GetParentName() string {
 // Export exports NodeGroup to orchestration.NodeGroupOptions
 func (n *NodeGroup) Export() (o orchestration.NodeGroupOptions) {
 	localVal := reflect.ValueOf(n).Elem()
-	localType := reflect.TypeOf(n).Elem()
+	localType := reflect.TypeFor[NodeGroup]()
 	remoteVal := reflect.ValueOf(&o).Elem()
 
 	for i := 0; i < localVal.NumField(); i++ {

--- a/pkg/random/random_test.go
+++ b/pkg/random/random_test.go
@@ -110,7 +110,7 @@ func TestPseudoGenerators(t *testing.T) {
 
 func TestInt64_Type(t *testing.T) {
 	v := random.Int64()
-	vt := reflect.TypeOf(v).Kind()
+	vt := reflect.TypeFor[int64]().Kind()
 
 	if vt != reflect.Int64 {
 		t.Errorf("unexpected type, expected: %v, got: %v", reflect.Int64, vt)
@@ -124,7 +124,7 @@ func TestInt64_Type(t *testing.T) {
 func TestCryptoSource_Uint64(t *testing.T) {
 	cs := random.CryptoSource{}
 	v := cs.Uint64()
-	vt := reflect.TypeOf(v).Kind()
+	vt := reflect.TypeFor[uint64]().Kind()
 
 	if vt != reflect.Uint64 {
 		t.Errorf("unexpected type, expected: %v, got: %v", reflect.Uint64, vt)
@@ -138,7 +138,7 @@ func TestCryptoSource_Uint64(t *testing.T) {
 func TestCryptoSource_Int63(t *testing.T) {
 	cs := random.CryptoSource{}
 	v := cs.Int63()
-	vt := reflect.TypeOf(v).Kind()
+	vt := reflect.TypeFor[int64]().Kind()
 
 	if vt != reflect.Int64 {
 		t.Errorf("unexpected type, expected: %v, got: %v", reflect.Int64, vt)


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)

Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.
More info https://github.com/golang/go/issues/60088

