### PR TITLE
fix(smoke): prevent busy loop on batch creation failure

### DIFF
--- a/pkg/check/smoke/smoke.go
+++ b/pkg/check/smoke/smoke.go
@@ -126,6 +126,8 @@ func (c *Check) run(ctx context.Context, cluster orchestration.Cluster, o Option
 		if err != nil {
 			c.logger.Errorf("create new batch failed: %v", err)
 			c.metrics.BatchCreateErrors.Inc()
+			c.logger.Infof("retrying in: %v", o.TxOnErrWait)
+			time.Sleep(o.TxOnErrWait)
 			continue
 		}
 


### PR DESCRIPTION
- Add retry delay when `GetOrCreateMutableBatch` fails to prevent rapid iteration and potential resource exhaustion.