### PR TITLE
chore: enhance CI with linting and whitespace checks in GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,8 +1,43 @@
 name: Go
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+    branches:
+      - '**'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          cache: false
+          go-version-file: go.mod
+      - name: Commit linting
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: commitlint.config.js
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.10.1
+          args: --timeout 10m
+          skip-cache: false
+      - name: Vet
+        run: make vet
+      - name: Whitespace check
+        run: make check-whitespace
+      - name: go mod tidy check
+        uses: katexochen/go-tidy-check@v2
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -30,16 +65,6 @@ jobs:
         # make sure that line endings are not converted on windows
         # as gofmt linter will report that they need to be changed
         run: git config --global core.autocrlf false
-      - name: Lint
-        if: matrix.os == 'ubuntu-latest'
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.10.1
-          args: --timeout 10m
-          skip-cache: false
-      - name: Vet
-        if: matrix.os == 'ubuntu-latest'
-        run: make vet
       - name: Build
         run: make build
       - name: Test

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,23 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  lint-title:
+    name: Lint PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install commitlint
+        run: npm install --save-dev @commitlint/cli @commitlint/config-conventional
+      - name: PR title linting
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint --config ./commitlint.config.js

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ linter:
 vet:
 	$(GO) vet ./...
 
+.PHONY: check-whitespace
+check-whitespace:
+	TREE=$$(git hash-object -t tree /dev/null); \
+	TW=$$(git diff-index --cached --check --diff-filter=d "$${TREE}"); \
+	[ "$${TW}" != "" ] && echo "Trailing whitespaces found:\n $${TW}" && exit 1; exit 0
+
 .PHONY: test-race
 test-race:
 	$(GO) test -race -v ./...

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ enable-k8s: true
 in-cluster: false
 kubeconfig: "~/.kube/config"
 geth-url: http://geth-swap.geth-swap.dai.internal
-bzz-token-address: 0x6aab14fe9cccd64a502d23842d916eb5321c26e7 
+bzz-token-address: 0x6aab14fe9cccd64a502d23842d916eb5321c26e7
 eth-account: 0x62cab2b3b55f341f10348720ca18063cdb779ad5
 log-verbosity: "info"
 loki-endpoint: http://loki.testnet.internal/loki/api/v1/push
@@ -595,7 +595,7 @@ It has the following subcommands:
   ```
 
   example:
-  
+
   ```bash
   beekeeper stamper create --cluster-name=default --amount=1000 --depth=16 --timeout=5m
   ```
@@ -624,7 +624,7 @@ It has the following subcommands:
   ```
 
   example:
-  
+
   ```bash
   beekeeper stamper topup --cluster-name=default --topup-to=720h --ttl-threshold=120h --periodic-check=1h --timeout=24h
   ```
@@ -653,7 +653,7 @@ It has the following subcommands:
   ```
 
   example:
-  
+
   ```bash
   beekeeper stamper dilute --cluster-name=default --dilution-depth=1 --usage-threshold=90 --periodic-check=1h --timeout=24h
   ```
@@ -684,7 +684,7 @@ It has the following subcommands:
   ```
 
   example:
-  
+
   ```bash
   beekeeper stamper set --cluster-name=default --dilution-depth=1 --usage-threshold=90 --ttl-threshold=120h --topup-to=720h --periodic-check=1h --timeout=24h
   ```

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,34 @@
+module.exports = {
+	rules: {
+		'body-leading-blank': [2, 'always'],
+		'body-case': [0, 'never'],
+		'footer-leading-blank': [1, 'always'],
+		'footer-max-line-length': [2, 'always', 72],
+		'header-max-length': [2, 'always', 98],
+		'subject-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+		],
+		'subject-empty': [2, 'never'],
+		'subject-full-stop': [2, 'never', '.'],
+		'type-case': [2, 'always', 'lower-case'],
+		'type-empty': [2, 'never'],
+		'type-enum': [
+			2,
+			'always',
+			[
+				'build',
+				'chore',
+				'ci',
+				'docs',
+				'feat',
+				'fix',
+				'perf',
+				'refactor',
+				'revert',
+				'test',
+			],
+		],
+	},
+};

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -335,7 +335,7 @@ checks:
     type: settlements
   smoke:
     options:
-      file-sizes: [31457280, 104857600, 314572800] # [30MB, 100MB, 300MB]  
+      file-sizes: [31457280, 104857600, 314572800] # [30MB, 100MB, 300MB]
       postage-ttl: 72h
       postage-depth: 21
       postage-label: test-label

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -465,4 +465,3 @@ checks:
       forge-dns-address: "127.0.0.1:30053" # When running inside cluster, use p2p-forge.local.svc.cluster.local:53
       forge-tls-host-address: "" # When running locally, use 127.0.0.1:31635
       pebble-mgmt-url: "https://127.0.0.1:31500/roots/0" # When running inside cluster, use https://pebble.local.svc.cluster.local:15000/roots/0
-

--- a/scripts/suite.sh
+++ b/scripts/suite.sh
@@ -3,12 +3,12 @@
 set -euo pipefail
 
 #/
-#/ Usage: 
+#/ Usage:
 #/ ./suite.sh ACTION [OPTION]
-#/ 
+#/
 #/ Description:
 #/ Run beekeeper tests on local or remote cluster
-#/ 
+#/
 #/ Example:
 #/ ./suite.sh all -n bee -r 3
 #/
@@ -123,7 +123,7 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
                 ACTION="settlements"
                 shift
             ;;
-            
+
 #/   cashout      run cashout test
             cashout)
                 ACTION="cashout"


### PR DESCRIPTION
## summary

Align beekeeper CI with ethersphere/bee: conventional commit lint on PRs, PR title lint, and extra quality checks (whitespace + go mod tidy). Splits lint onto Ubuntu only and keeps build/test on the OS matrix.

## changes

- add `commitlint.config.js` at repo root (`@commitlint/config-conventional` rules, header max length **98**)
- add `.github/workflows/pr-title.yml` — lint PR title on `opened`, `synchronize`, `reopened`, `edited`
- update `.github/workflows/go.yml`:
  - `pull_request` with `paths-ignore: '**/*.md'` for the Go workflow
  - new `lint` job: full history checkout, `wagoid/commitlint-github-action@v5`, golangci-lint, `make vet`, `make check-whitespace`, `katexochen/go-tidy-check@v2`
  - `build` job: matrix build + test only (shallow checkout)
- add `check-whitespace` target to `Makefile` (same idea as bee)
- fix existing trailing whitespace / EOF whitespace issues so the new check passes

## why

Keeps commit and merge messages consistent across swarm repos and catches bad titles/commits before merge.

## notes

- Markdown-only PRs skip the Go workflow but still get PR title lint.
- Update branch protection if you want `Lint` and `Lint PR Title` required.

Refs: ethersphere/bee `go.yml`, `pr-title.yml`, `commitlint.config.js`.