### PR TITLE
feat(config): support new bee OTLP tracing flags

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -124,7 +124,7 @@ bee-configs:
     swap-factory-address: "0xdD661f2500bA5831e3d1FEbAc379Ea1bF80773Ac"
     swap-initial-deposit: 500000000000000000
     tracing-enabled: true
-    tracing-endpoint: "10.10.11.199:6831"
+    tracing-otlp-endpoint: "10.10.11.199:4318"
     tracing-service-name: "bee"
     verbosity: 5 # 1=error, 2=warn, 3=info, 4=debug, 5=trace
     warmup-time: 0s

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -42,7 +42,7 @@ bee-configs:
     password: "beekeeper"
     swap-enable: true
     tracing-enabled: true
-    tracing-endpoint: "10.10.11.199:6831"
+    tracing-otlp-endpoint: "10.10.11.199:4318"
     tracing-service-name: "bee"
     verbosity: 4
     welcome-message: Welcome to the bee staging environment created by Beekeeper!

--- a/config/testnet-bee-playground.yaml
+++ b/config/testnet-bee-playground.yaml
@@ -69,7 +69,7 @@ bee-configs:
     swap-enable: true
     swap-initial-deposit: 0
     tracing-enabled: false
-    tracing-endpoint: "10.10.11.199:6831"
+    tracing-otlp-endpoint: "10.10.11.199:4318"
     tracing-service-name: "bee-playground"
     verbosity: 5
     warmup-time: 5m0s

--- a/pkg/config/bee.go
+++ b/pkg/config/bee.go
@@ -100,5 +100,13 @@ func (b *BeeConfig) Export() (config orchestration.Config) {
 		config.BlockchainRPCEndpoint = *b.SwapEndpoint
 	}
 
+	// Bee's tracing-sampling-ratio semantics: 0 disables sampling, 1 samples
+	// everything. Default to 1 when unset so existing beekeeper configs (which
+	// never specified the key) keep the prior "sample everything" behavior
+	// rather than silently turning tracing off.
+	if b.TracingSamplingRatio == nil {
+		config.TracingSamplingRatio = 1.0
+	}
+
 	return config
 }

--- a/pkg/config/bee.go
+++ b/pkg/config/bee.go
@@ -58,7 +58,9 @@ type BeeConfig struct {
 	SwapFactoryAddress          *string        `yaml:"swap-factory-address"`
 	SwapInitialDeposit          *uint64        `yaml:"swap-initial-deposit"`
 	TracingEnabled              *bool          `yaml:"tracing-enabled"`
-	TracingEndpoint             *string        `yaml:"tracing-endpoint"`
+	TracingOTLPEndpoint         *string        `yaml:"tracing-otlp-endpoint"`
+	TracingOTLPInsecure         *bool          `yaml:"tracing-otlp-insecure"`
+	TracingSamplingRatio        *float64       `yaml:"tracing-sampling-ratio"`
 	TracingServiceName          *string        `yaml:"tracing-service-name"`
 	Verbosity                   *uint64        `yaml:"verbosity"`
 	WarmupTime                  *time.Duration `yaml:"warmup-time"`

--- a/pkg/orchestration/k8s/helpers.go
+++ b/pkg/orchestration/k8s/helpers.go
@@ -56,7 +56,9 @@ swap-enable: {{.SwapEnable}}
 swap-factory-address: {{.SwapFactoryAddress}}
 swap-initial-deposit: {{.SwapInitialDeposit}}
 tracing-enable: {{.TracingEnabled}}
-tracing-endpoint: {{.TracingEndpoint}}
+tracing-otlp-endpoint: {{.TracingOTLPEndpoint}}
+tracing-otlp-insecure: {{.TracingOTLPInsecure}}
+tracing-sampling-ratio: {{.TracingSamplingRatio}}
 tracing-service-name: {{.TracingServiceName}}
 verbosity: {{.Verbosity}}
 warmup-time: {{.WarmupTime}}

--- a/pkg/orchestration/node.go
+++ b/pkg/orchestration/node.go
@@ -116,7 +116,9 @@ type Config struct {
 	SwapFactoryAddress          string        // swap factory address
 	SwapInitialDeposit          uint64        // initial deposit if deploying a new chequebook
 	TracingEnabled              bool          // enable tracing
-	TracingEndpoint             string        // endpoint to send tracing data
+	TracingOTLPEndpoint         string        // OTLP/HTTP endpoint for tracing data (host:port)
+	TracingOTLPInsecure         bool          // disable TLS for the OTLP exporter
+	TracingSamplingRatio        float64       // head-based sampling ratio in [0,1]; 1 samples everything
 	TracingServiceName          string        // service name identifier for tracing
 	Verbosity                   uint64        // log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace
 	WarmupTime                  time.Duration // warmup time pull/pushsync protocols


### PR DESCRIPTION
Paired change for the bee OpenTelemetry migration https://github.com/ethersphere/bee/pull/5456 Bee renamed its tracing CLI flags and dropped the legacy Jaeger thrift UDP endpoint; without this PR, beekeeper-managed deployments would fail to start once the bee PR ships.