### PR TITLE
feat(config): rename tracing-otlp-* flags to tracing-*

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -124,7 +124,7 @@ bee-configs:
     swap-factory-address: "0xdD661f2500bA5831e3d1FEbAc379Ea1bF80773Ac"
     swap-initial-deposit: 500000000000000000
     tracing-enabled: true
-    tracing-otlp-endpoint: "10.10.11.199:4318"
+    tracing-endpoint: "10.10.11.199:4318"
     tracing-service-name: "bee"
     verbosity: 5 # 1=error, 2=warn, 3=info, 4=debug, 5=trace
     warmup-time: 0s

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -42,7 +42,7 @@ bee-configs:
     password: "beekeeper"
     swap-enable: true
     tracing-enabled: true
-    tracing-otlp-endpoint: "10.10.11.199:4318"
+    tracing-endpoint: "10.10.11.199:4318"
     tracing-service-name: "bee"
     verbosity: 4
     welcome-message: Welcome to the bee staging environment created by Beekeeper!

--- a/config/testnet-bee-playground.yaml
+++ b/config/testnet-bee-playground.yaml
@@ -69,7 +69,7 @@ bee-configs:
     swap-enable: true
     swap-initial-deposit: 0
     tracing-enabled: false
-    tracing-otlp-endpoint: "10.10.11.199:4318"
+    tracing-endpoint: "10.10.11.199:4318"
     tracing-service-name: "bee-playground"
     verbosity: 5
     warmup-time: 5m0s

--- a/pkg/config/bee.go
+++ b/pkg/config/bee.go
@@ -58,9 +58,9 @@ type BeeConfig struct {
 	SwapFactoryAddress          *string        `yaml:"swap-factory-address"`
 	SwapInitialDeposit          *uint64        `yaml:"swap-initial-deposit"`
 	TracingEnabled              *bool          `yaml:"tracing-enabled"`
-	TracingOTLPEndpoint         *string        `yaml:"tracing-otlp-endpoint"`
-	TracingOTLPInsecure         *bool          `yaml:"tracing-otlp-insecure"`
-	TracingOTLPProtocol         *string        `yaml:"tracing-otlp-protocol"`
+	TracingOTLPEndpoint         *string        `yaml:"tracing-endpoint"`
+	TracingOTLPInsecure         *bool          `yaml:"tracing-insecure"`
+	TracingOTLPProtocol         *string        `yaml:"tracing-protocol"`
 	TracingSamplingRatio        *float64       `yaml:"tracing-sampling-ratio"`
 	TracingServiceName          *string        `yaml:"tracing-service-name"`
 	Verbosity                   *uint64        `yaml:"verbosity"`

--- a/pkg/orchestration/k8s/helpers.go
+++ b/pkg/orchestration/k8s/helpers.go
@@ -56,9 +56,9 @@ swap-enable: {{.SwapEnable}}
 swap-factory-address: {{.SwapFactoryAddress}}
 swap-initial-deposit: {{.SwapInitialDeposit}}
 tracing-enable: {{.TracingEnabled}}
-tracing-otlp-endpoint: {{.TracingOTLPEndpoint}}
-tracing-otlp-insecure: {{.TracingOTLPInsecure}}
-tracing-otlp-protocol: {{.TracingOTLPProtocol}}
+tracing-endpoint: {{.TracingOTLPEndpoint}}
+tracing-insecure: {{.TracingOTLPInsecure}}
+tracing-protocol: {{.TracingOTLPProtocol}}
 tracing-sampling-ratio: {{.TracingSamplingRatio}}
 tracing-service-name: {{.TracingServiceName}}
 verbosity: {{.Verbosity}}


### PR DESCRIPTION
Companion to bee PR ethersphere/bee#5502, which renames bee's tracing flags to drop the `otlp` infix (`tracing-otlp-endpoint/-insecure/-protocol` , `tracing-endpoint/-insecure/-protocol`; `tracing-endpoint` is reused as the active OTLP collector endpoint). beekeeper must emit the new key names or bee rejects them as unknown parameters.

  This is intentionally stacked on #598 rather than changing it directly: #598 stays paired with the original migration PR ethersphere/bee#5456 (old keys), and this branch pairs with bee#5502 (new keys)