### PR TITLE
feat(pingpong): ping only cluster peers by default

### DIFF
--- a/pkg/check/fullconnectivity/fullconnectivity.go
+++ b/pkg/check/fullconnectivity/fullconnectivity.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/beekeeper/pkg/beekeeper"
 	"github.com/ethersphere/beekeeper/pkg/logging"
 	"github.com/ethersphere/beekeeper/pkg/orchestration"
@@ -87,7 +86,7 @@ func (c *Check) checkFullNodesConnectivity(ctx context.Context, cluster orchestr
 			}
 
 			for _, p := range allPeers {
-				if !contains(overlays, p) {
+				if !overlays.Contains(p) {
 					c.logger.Infof("Node %s. Failed. Invalid peer: %s. Node: %s", node, p.String(), overlay)
 					return errFullConnectivity
 				}
@@ -130,7 +129,7 @@ func (c *Check) checkLightNodesConnectivity(ctx context.Context, cluster orchest
 			}
 
 			for _, p := range allPeers {
-				if !contains(overlays, p) {
+				if !overlays.Contains(p) {
 					c.logger.Infof("Node %s. Failed. Invalid peer: %s. Node: %s", node, p.String(), overlay)
 					return errFullConnectivity
 				}
@@ -141,17 +140,4 @@ func (c *Check) checkLightNodesConnectivity(ctx context.Context, cluster orchest
 	}
 
 	return err
-}
-
-// contains checks if a given set of swarm.Address contains given swarm.Address
-func contains(s orchestration.ClusterOverlays, a swarm.Address) bool {
-	for _, v := range s {
-		for _, o := range v {
-			if o.Equal(a) {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/pkg/check/pingpong/pingpong.go
+++ b/pkg/check/pingpong/pingpong.go
@@ -3,6 +3,7 @@ package pingpong
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -14,11 +15,16 @@ import (
 )
 
 // Options represents check options
-type Options struct{}
+type Options struct {
+	// PingAllPeers, when true, also pings peers outside the defined cluster.
+	PingAllPeers bool
+}
 
 // NewDefaultOptions returns new default options
 func NewDefaultOptions() Options {
-	return Options{}
+	return Options{
+		PingAllPeers: false,
+	}
 }
 
 // compile check whether Check implements interface
@@ -39,7 +45,20 @@ func NewCheck(logger logging.Logger) beekeeper.Action {
 }
 
 // Run executes ping check
-func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, _ any) (err error) {
+func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, opts any) (err error) {
+	o, ok := opts.(Options)
+	if !ok {
+		return fmt.Errorf("invalid options type")
+	}
+
+	var clusterOverlays orchestration.ClusterOverlays
+	if !o.PingAllPeers {
+		clusterOverlays, err = cluster.Overlays(ctx)
+		if err != nil {
+			return fmt.Errorf("get overlays: %w", err)
+		}
+	}
+
 	nodeGroups := cluster.NodeGroups()
 	for _, ng := range nodeGroups {
 		nodesClients, err := ng.NodesClients(ctx)
@@ -47,7 +66,7 @@ func (c *Check) Run(ctx context.Context, cluster orchestration.Cluster, _ any) (
 			return fmt.Errorf("get nodes clients: %w", err)
 		}
 
-		for n := range nodeStream(ctx, nodesClients) { // TODO: confirm use case for nodeStream(ctx, ng.NodesClientsAll(ctx))
+		for n := range nodeStream(ctx, nodesClients, clusterOverlays, o.PingAllPeers) { // TODO: confirm use case for nodeStream(ctx, ng.NodesClientsAll(ctx))
 			for t := range 5 {
 				time.Sleep(2 * time.Duration(t) * time.Second)
 
@@ -86,7 +105,9 @@ type nodeStreamMsg struct {
 	Error       error
 }
 
-func nodeStream(ctx context.Context, nodes map[string]*bee.Client) <-chan nodeStreamMsg {
+// nodeStream pings each node's peers concurrently. Unless pingAllPeers is set,
+// peers outside the cluster are skipped.
+func nodeStream(ctx context.Context, nodes map[string]*bee.Client, clusterOverlays orchestration.ClusterOverlays, pingAllPeers bool) <-chan nodeStreamMsg {
 	nodeStream := make(chan nodeStreamMsg)
 
 	var wg sync.WaitGroup
@@ -106,6 +127,11 @@ func nodeStream(ctx context.Context, nodes map[string]*bee.Client) <-chan nodeSt
 				nodeStream <- nodeStreamMsg{Name: name, Error: err}
 				return
 			}
+			if !pingAllPeers {
+				peers = slices.DeleteFunc(peers, func(p swarm.Address) bool {
+					return !clusterOverlays.Contains(p)
+				})
+			}
 			if len(peers) == 0 {
 				nodeStream <- nodeStreamMsg{Name: name, Error: fmt.Errorf("no peers")}
 				return
@@ -114,6 +140,7 @@ func nodeStream(ctx context.Context, nodes map[string]*bee.Client) <-chan nodeSt
 			for m := range node.PingStream(ctx, peers) {
 				if m.Error != nil {
 					nodeStream <- nodeStreamMsg{Name: name, Error: m.Error}
+					continue
 				}
 				nodeStream <- nodeStreamMsg{
 					Name:        name,

--- a/pkg/config/check.go
+++ b/pkg/config/check.go
@@ -294,7 +294,18 @@ var Checks = map[string]CheckType{
 	"pingpong": {
 		NewAction: pingpong.NewCheck,
 		NewOptions: func(checkGlobalConfig CheckGlobalConfig, check Check) (any, error) {
+			checkOpts := new(struct {
+				PingAllPeers *bool `yaml:"ping-all-peers"`
+			})
+			if err := check.Options.Decode(checkOpts); err != nil {
+				return nil, fmt.Errorf("decoding check %s options: %w", check.Type, err)
+			}
 			opts := pingpong.NewDefaultOptions()
+
+			if err := applyCheckConfig(checkGlobalConfig, checkOpts, &opts); err != nil {
+				return nil, fmt.Errorf("applying options: %w", err)
+			}
+
 			return opts, nil
 		},
 	},

--- a/pkg/orchestration/cluster.go
+++ b/pkg/orchestration/cluster.go
@@ -78,6 +78,18 @@ type (
 	ClientMap  map[string]*bee.Client
 )
 
+// Contains reports whether addr is the overlay of any node in the cluster.
+func (c ClusterOverlays) Contains(addr swarm.Address) bool {
+	for _, ngo := range c {
+		for _, overlay := range ngo {
+			if overlay.Equal(addr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // RandomOverlay returns a random overlay from a random NodeGroup
 func (c ClusterOverlays) Random(r *rand.Rand) (nodeGroup string, nodeName string, overlay swarm.Address) {
 	i := r.Intn(len(c))


### PR DESCRIPTION
On public-testnet there are "foreign" peers that connect/disconnect and current pingpong check is trying to ping them, but they are not avaiable. With this changes, pingpong will be only executed on those peers known in the defined cluster