### PR TITLE
feat(metrics): attach cluster/namespace grouping labels to pushed metrics

### DIFF
--- a/cmd/beekeeper/cmd/check.go
+++ b/cmd/beekeeper/cmd/check.go
@@ -22,6 +22,7 @@ func (c *command) initCheckCmd() error {
 		optionNameSeed                 = "seed"
 		optionNameTimeout              = "timeout"
 		optionNameMetricsPusherAddress = "metrics-pusher-address"
+		optionNameMetricsLabels        = "metrics-labels"
 	)
 
 	cmd := &cobra.Command{
@@ -70,7 +71,13 @@ Use --metrics-enabled to collect and push metrics to Prometheus.`,
 				)
 
 				if metricsEnabled {
-					metricsPusher, cleanup = newMetricsPusher(c.globalConfig.GetString(optionNameMetricsPusherAddress), cfgCluster.GetNamespace(), c.log)
+					namespace := cfgCluster.GetNamespace()
+					metricsPusher, cleanup = newMetricsPusher(
+						c.globalConfig.GetString(optionNameMetricsPusherAddress),
+						namespace,
+						metricsGroupingLabels(clusterName, namespace, c.globalConfig.GetStringMapString(optionNameMetricsLabels)),
+						c.log,
+					)
 					// cleanup executes when the calling context terminates
 					defer cleanup()
 				}
@@ -111,6 +118,7 @@ Use --metrics-enabled to collect and push metrics to Prometheus.`,
 
 	cmd.Flags().String(optionNameClusterName, "", "cluster name. Required")
 	cmd.Flags().String(optionNameMetricsPusherAddress, "pushgateway.staging.internal", "prometheus metrics pusher address")
+	cmd.Flags().StringToString(optionNameMetricsLabels, nil, "extra Prometheus grouping labels added to every pushed metric (e.g. --metrics-labels team=swarm,ci_run=123); 'cluster' and 'namespace' labels are added automatically")
 	cmd.Flags().Bool(optionNameCreateCluster, false, "creates cluster before executing checks")
 	cmd.Flags().StringSlice(optionNameChecks, []string{"pingpong"}, "list of checks to execute")
 	cmd.Flags().Bool(optionNameMetricsEnabled, true, "enable metrics")

--- a/cmd/beekeeper/cmd/metrics.go
+++ b/cmd/beekeeper/cmd/metrics.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"maps"
 	"sync"
 	"time"
 
@@ -9,10 +10,19 @@ import (
 	"github.com/prometheus/common/expfmt"
 )
 
-// newMetricsPusher returns a new metrics pusher and a cleanup function.
-func newMetricsPusher(pusherAddress, job string, logger logging.Logger) (*push.Pusher, func()) {
+// newMetricsPusher returns a new metrics pusher and a cleanup function. job sets
+// the Pushgateway "job" label; groupingLabels become part of the grouping key, so
+// Pushgateway attaches them to every pushed series (Vec and non-Vec alike).
+func newMetricsPusher(pusherAddress, job string, groupingLabels map[string]string, logger logging.Logger) (*push.Pusher, func()) {
 	metricsPusher := push.New(pusherAddress, job)
 	metricsPusher.Format(expfmt.NewFormat(expfmt.TypeTextPlain))
+
+	for name, value := range groupingLabels {
+		if value == "" {
+			continue
+		}
+		metricsPusher.Grouping(name, value)
+	}
 
 	killC := make(chan struct{})
 	var wg sync.WaitGroup
@@ -39,4 +49,17 @@ func newMetricsPusher(pusherAddress, job string, logger logging.Logger) (*push.P
 		}
 	}
 	return metricsPusher, cleanupFn
+}
+
+// metricsGroupingLabels merges the run's identity labels (cluster and namespace,
+// always present so metrics can be filtered by them) with operator-supplied
+// labels, which take precedence. Keys must be valid Prometheus label names,
+// otherwise every push fails.
+func metricsGroupingLabels(clusterName, namespace string, custom map[string]string) map[string]string {
+	labels := map[string]string{
+		"cluster":   clusterName,
+		"namespace": namespace,
+	}
+	maps.Copy(labels, custom)
+	return labels
 }

--- a/cmd/beekeeper/cmd/simulate.go
+++ b/cmd/beekeeper/cmd/simulate.go
@@ -22,6 +22,7 @@ func (c *command) initSimulateCmd() (err error) {
 		optionNameSeed                 = "seed"
 		optionNameTimeout              = "timeout"
 		optionNameMetricsPusherAddress = "metrics-pusher-address"
+		optionNameMetricsLabels        = "metrics-labels"
 	)
 
 	cmd := &cobra.Command{
@@ -68,7 +69,13 @@ Use --metrics-enabled to collect performance metrics during simulation.`,
 			)
 
 			if metricsEnabled {
-				metricsPusher, cleanup = newMetricsPusher(c.globalConfig.GetString(optionNameMetricsPusherAddress), cfgCluster.GetNamespace(), c.log)
+				namespace := cfgCluster.GetNamespace()
+				metricsPusher, cleanup = newMetricsPusher(
+					c.globalConfig.GetString(optionNameMetricsPusherAddress),
+					namespace,
+					metricsGroupingLabels(clusterName, namespace, c.globalConfig.GetStringMapString(optionNameMetricsLabels)),
+					c.log,
+				)
 				// cleanup executes when the calling context terminates
 				defer cleanup()
 			}
@@ -138,6 +145,7 @@ Use --metrics-enabled to collect performance metrics during simulation.`,
 
 	cmd.Flags().String(optionNameClusterName, "default", "cluster name")
 	cmd.Flags().String(optionNameMetricsPusherAddress, "pushgateway.staging.internal", "prometheus metrics pusher address")
+	cmd.Flags().StringToString(optionNameMetricsLabels, nil, "extra Prometheus grouping labels added to every pushed metric (e.g. --metrics-labels team=swarm,ci_run=123); 'cluster' and 'namespace' labels are added automatically")
 	cmd.Flags().Bool(optionNameCreateCluster, false, "creates cluster before executing simulations")
 	cmd.Flags().StringSlice(optionNameSimulations, []string{"upload"}, "list of simulations to execute")
 	cmd.Flags().Bool(optionNameMetricsEnabled, true, "enable metrics")


### PR DESCRIPTION
## Attach cluster/namespace grouping labels to pushed metrics

Checks/simulations pushed metrics with only the `job` label (= namespace), so runs sharing a namespace collapsed together with no way to tell clusters or runs apart.

This adds Pushgateway grouping labels applied to every pushed series (Vec and non-Vec): `cluster` and `namespace` are added automatically, plus a new `--metrics-labels` flag (on `check` and `simulate`) for arbitrary operator labels, e.g. `--metrics-labels team=swarm,ci_run=123` (operator labels take precedence).

Filter in Prometheus/Grafana with `{cluster="...", namespace="..."}`; cluster+namespace identifies a run but isn't a concurrency key, so parallel runs against one cluster should add a distinguishing label like `ci_run`.
